### PR TITLE
Fix/auth/response

### DIFF
--- a/bindings-test/src/multitest.rs
+++ b/bindings-test/src/multitest.rs
@@ -20,13 +20,13 @@ use elys_bindings::{
         MsgResponse,
     },
     query_resp::{
-        AmmSwapEstimationByDenomResponse, AmmSwapEstimationResponse, AuthAccountsResponse, Entry,
+        AmmSwapEstimationByDenomResponse, AmmSwapEstimationResponse, Entry,
         MarginGetPositionsForAddressResponse, MarginMtpResponse, MarginOpenEstimationResponse,
         MarginQueryPositionsResponse, QueryGetEntryResponse,
     },
     types::{
-        BalanceAvailable, BaseAccount, Mtp, OracleAssetInfo, PageResponse, Price, PublicKey, Sum,
-        SwapAmountInRoute, SwapAmountOutRoute,
+        BalanceAvailable, Mtp, OracleAssetInfo, PageResponse, Price, SwapAmountInRoute,
+        SwapAmountOutRoute,
     },
     ElysMsg, ElysQuery,
 };
@@ -37,7 +37,7 @@ pub const ASSET_INFO: Item<Vec<OracleAssetInfo>> = Item::new("asset_info");
 pub const BLOCK_TIME: u64 = 5;
 pub const MARGIN_OPENED_POSITION: Item<Vec<Mtp>> = Item::new("margin_opened_position");
 pub const LAST_MODULE_USED: Item<Option<String>> = Item::new("last_module_used");
-pub const ACCOUNT: Item<Vec<BaseAccount>> = Item::new("account");
+pub const ACCOUNT: Item<Vec<String>> = Item::new("account");
 
 pub struct ElysModule {}
 
@@ -55,16 +55,9 @@ impl ElysModule {
     }
 
     pub fn new_account(&self, store: &mut dyn Storage, addr: impl Into<String>) -> StdResult<()> {
-        let mut accounts: Vec<BaseAccount> = ACCOUNT.load(store)?;
+        let mut accounts = ACCOUNT.load(store)?;
         let addr: String = addr.into();
-
-        accounts.push(BaseAccount {
-            pub_key: PublicKey::set(Sum::Ed25519(to_json_binary(&addr)?)),
-            address: addr,
-            account_number: 0,
-            sequence: 0,
-        });
-
+        accounts.push(addr);
         ACCOUNT.save(store, &accounts)
     }
 
@@ -232,16 +225,6 @@ impl Module for ElysModule {
                     pagination: page_resp,
                 })?)
             }
-            ElysQuery::AuthAccounts { pagination } => {
-                let acc = ACCOUNT.load(storage)?;
-                let (accounts, pagination) = pagination.filter(acc)?;
-                let resp = AuthAccountsResponse {
-                    accounts,
-                    pagination,
-                };
-
-                Ok(to_json_binary(&resp)?)
-            }
             ElysQuery::AmmBalance { .. } => {
                 let resp = BalanceAvailable {
                     amount: Uint128::new(100),
@@ -312,6 +295,10 @@ impl Module for ElysModule {
                     mtps: user_mtps,
                     pagination: PageResponse::empty(false),
                 })?)
+            }
+            ElysQuery::AuthAddresses { .. } => {
+                let addresses = ACCOUNT.load(storage)?;
+                Ok(to_json_binary(&addresses)?)
             }
         }
     }
@@ -689,7 +676,7 @@ impl Default for ElysApp {
 
 impl ElysApp {
     pub fn new_with_wallets(wallets: Vec<(&str, Vec<Coin>)>) -> Self {
-        let mut accounts: Vec<BaseAccount> = vec![];
+        let mut addresses: Vec<String> = vec![];
         Self(
             BasicAppBuilder::<ElysMsg, ElysQuery>::new_custom()
                 .with_custom(ElysModule {})
@@ -699,16 +686,9 @@ impl ElysApp {
                             .bank
                             .init_balance(storage, &Addr::unchecked(wallet_owner), wallet_contenent)
                             .unwrap();
-                        accounts.push(BaseAccount {
-                            address: wallet_owner.to_owned(),
-                            pub_key: PublicKey::set(Sum::Ed25519(
-                                to_json_binary(wallet_owner).unwrap(),
-                            )),
-                            account_number: 0,
-                            sequence: 0,
-                        })
+                        addresses.push(wallet_owner.to_owned())
                     }
-                    ACCOUNT.save(storage, &accounts).unwrap();
+                    ACCOUNT.save(storage, &addresses).unwrap();
                     MARGIN_OPENED_POSITION.save(storage, &vec![]).unwrap();
                     ASSET_INFO.save(storage, &vec![]).unwrap();
                     PRICES.save(storage, &vec![]).unwrap();

--- a/bindings-test/src/multitest.rs
+++ b/bindings-test/src/multitest.rs
@@ -20,9 +20,9 @@ use elys_bindings::{
         MsgResponse,
     },
     query_resp::{
-        AmmSwapEstimationByDenomResponse, AmmSwapEstimationResponse, Entry,
+        AmmSwapEstimationByDenomResponse, AmmSwapEstimationResponse, AuthAddressesResponse, Entry,
         MarginGetPositionsForAddressResponse, MarginMtpResponse, MarginOpenEstimationResponse,
-        MarginQueryPositionsResponse, QueryGetEntryResponse,
+        MarginQueryPositionsResponse, OracleAssetInfoResponse, QueryGetEntryResponse,
     },
     types::{
         BalanceAvailable, Mtp, OracleAssetInfo, PageResponse, Price, SwapAmountInRoute,
@@ -108,7 +108,9 @@ impl Module for ElysModule {
                 let may_have_info = infos.iter().find(|asset| asset.denom == denom);
 
                 match may_have_info {
-                    Some(info) => Ok(to_json_binary(info)?),
+                    Some(info) => Ok(to_json_binary(&OracleAssetInfoResponse {
+                        asset_info: info.to_owned(),
+                    })?),
                     None => Err(Error::new(StdError::not_found("asset denom"))),
                 }
             }
@@ -298,7 +300,11 @@ impl Module for ElysModule {
             }
             ElysQuery::AuthAddresses { .. } => {
                 let addresses = ACCOUNT.load(storage)?;
-                Ok(to_json_binary(&addresses)?)
+                let res = AuthAddressesResponse {
+                    addresses,
+                    pagination: PageResponse::empty(false),
+                };
+                Ok(to_json_binary(&res)?)
             }
         }
     }

--- a/bindings-test/src/tests.rs
+++ b/bindings-test/src/tests.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
 use cw_multi_test::Executor;
 use elys_bindings::{
     query_resp::{
-        AmmSwapEstimationResponse, AuthAccountsResponse, MarginMtpResponse,
+        AmmSwapEstimationResponse, AuthAddressesResponse, MarginMtpResponse,
         MarginQueryPositionsResponse,
     },
     types::{MarginPosition, Mtp, OracleAssetInfo, PageRequest, Price, SwapAmountInRoute},
@@ -471,12 +471,9 @@ fn auth_account() {
     let wallets: Vec<(&str, Vec<Coin>)> =
         vec![("user", coins(5, "btc")), ("user2", coins(1, "usdc"))];
     let app = ElysApp::new_with_wallets(wallets.clone());
-    let req = ElysQuery::AuthAccounts {
-        pagination: PageRequest::new(200),
-    }
-    .into();
-    let resp: AuthAccountsResponse = app.wrap().query(&req).unwrap();
+    let req = ElysQuery::AuthAddresses { pagination: None }.into();
+    let resp: AuthAddressesResponse = app.wrap().query(&req).unwrap();
 
-    assert_eq!(resp.accounts[0].address, wallets[0].0);
-    assert_eq!(resp.accounts[1].address, wallets[1].0);
+    assert_eq!(resp.addresses[0], wallets[0].0);
+    assert_eq!(resp.addresses[1], wallets[1].0);
 }

--- a/bindings-test/src/tests.rs
+++ b/bindings-test/src/tests.rs
@@ -6,7 +6,7 @@ use cw_multi_test::Executor;
 use elys_bindings::{
     query_resp::{
         AmmSwapEstimationResponse, AuthAddressesResponse, MarginMtpResponse,
-        MarginQueryPositionsResponse,
+        MarginQueryPositionsResponse, OracleAssetInfoResponse,
     },
     types::{MarginPosition, Mtp, OracleAssetInfo, PageRequest, Price, SwapAmountInRoute},
     ElysMsg, ElysQuery,
@@ -103,9 +103,9 @@ fn asset_info() {
 
     let req = ElysQuery::oracle_asset_info("uatom".to_string()).into();
 
-    let queried_infos: OracleAssetInfo = app.wrap().query(&req).unwrap();
+    let queried_infos: OracleAssetInfoResponse = app.wrap().query(&req).unwrap();
 
-    assert_eq!(infos[0], queried_infos);
+    assert_eq!(infos[0], queried_infos.asset_info);
 }
 
 #[test]

--- a/bindings/src/querier.rs
+++ b/bindings/src/querier.rs
@@ -79,10 +79,12 @@ impl<'a> ElysQuerier<'a> {
         let resp: MarginQueryPositionsResponse = self.querier.query(&request)?;
         Ok(resp)
     }
-    pub fn accounts(&self, pagination: PageRequest) -> StdResult<AuthAccountsResponse> {
+    pub fn accounts(&self, pagination: Option<PageRequest>) -> StdResult<AuthAddressesResponse> {
         let request = QueryRequest::Custom(ElysQuery::accounts(pagination));
-        let resp: AuthAccountsResponse = self.querier.query(&request)?;
-        Ok(resp)
+
+        let res: AuthAddressesResponse = self.querier.query(&request)?;
+
+        Ok(res)
     }
 
     pub fn get_balance(&self, address: String, denom: String) -> StdResult<BalanceAvailable> {

--- a/bindings/src/query.rs
+++ b/bindings/src/query.rs
@@ -52,8 +52,8 @@ pub enum ElysQuery {
         pagination: PageRequest,
     },
     // Define AuthQuery
-    #[returns(AuthAccountsResponse)]
-    AuthAccounts { pagination: PageRequest },
+    #[returns(AuthAddressesResponse)]
+    AuthAddresses { pagination: Option<PageRequest> },
     #[returns(QueryGetEntryResponse)]
     AssetProfileEntry { base_denom: String },
 }
@@ -87,8 +87,8 @@ impl ElysQuery {
     pub fn positions(pagination: PageRequest) -> Self {
         Self::MarginQueryPositions { pagination }
     }
-    pub fn accounts(pagination: PageRequest) -> Self {
-        Self::AuthAccounts { pagination }
+    pub fn accounts(pagination: Option<PageRequest>) -> Self {
+        Self::AuthAddresses { pagination }
     }
 
     pub fn amm_swap_estimation_by_denom(

--- a/bindings/src/query_resp.rs
+++ b/bindings/src/query_resp.rs
@@ -2,7 +2,7 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Coin, Decimal, Int128, SignedDecimal, SignedDecimal256};
 
 use crate::types::{
-    BaseAccount, Mtp, OracleAssetInfo, PageResponse, Price, SwapAmountInRoute, SwapAmountOutRoute,
+    Mtp, OracleAssetInfo, PageResponse, Price, SwapAmountInRoute, SwapAmountOutRoute,
 };
 
 #[cw_serde]
@@ -37,8 +37,8 @@ pub struct MarginMtpResponse {
 }
 
 #[cw_serde]
-pub struct AuthAccountsResponse {
-    pub accounts: Vec<BaseAccount>,
+pub struct AuthAddressesResponse {
+    pub addresses: Vec<String>,
     pub pagination: PageResponse,
 }
 

--- a/bindings/src/types.rs
+++ b/bindings/src/types.rs
@@ -251,35 +251,6 @@ pub struct Mtp {
 }
 
 #[cw_serde]
-pub enum Sum {
-    Ed25519(Binary),
-    Secp256k1(Binary),
-}
-
-#[cw_serde]
-pub struct PublicKey(Sum);
-
-impl PublicKey {
-    pub fn get_sum(&self) -> Sum {
-        self.0.clone()
-    }
-}
-#[cfg(feature = "testing")]
-impl PublicKey {
-    pub fn set(sum: Sum) -> Self {
-        Self(sum)
-    }
-}
-
-#[cw_serde]
-pub struct BaseAccount {
-    pub address: String,
-    pub pub_key: PublicKey,
-    pub account_number: u64,
-    pub sequence: u64,
-}
-
-#[cw_serde]
 pub enum EarnType {
     AllProgram = 0,
     UsdcProgram = 1,

--- a/contracts/account-history-contract/src/action/sudo/update_account.rs
+++ b/contracts/account-history-contract/src/action/sudo/update_account.rs
@@ -8,6 +8,7 @@ use super::*;
 
 pub fn update_account(deps: DepsMut<ElysQuery>, env: Env) -> StdResult<Response<ElysMsg>> {
     let querier = ElysQuerier::new(&deps.querier);
+    let value_denom = VALUE_DENOM.load(deps.storage)?;
 
     let mut pagination = PAGINATION.load(deps.storage)?;
     let expiration = EXPIRATION.load(deps.storage)?;
@@ -24,8 +25,13 @@ pub fn update_account(deps: DepsMut<ElysQuery>, env: Env) -> StdResult<Response<
             vec![]
         };
         let account_balences = deps.querier.query_all_balances(&address)?;
-        let new_part: AccountValue =
-            create_new_part(&env.block, &querier, &expiration, account_balences)?;
+        let new_part: AccountValue = create_new_part(
+            &env.block,
+            &querier,
+            &expiration,
+            account_balences,
+            &value_denom,
+        )?;
         history.push(new_part);
         HISTORY.save(deps.storage, &address, &history)?;
     }
@@ -38,6 +44,7 @@ fn create_new_part(
     querier: &ElysQuerier<'_>,
     expiration: &Expiration,
     account_balences: Vec<Coin>,
+    value_denom: &String,
 ) -> StdResult<AccountValue> {
     let date = match expiration {
         Expiration::AtHeight(_) => Expiration::AtHeight(block.height),
@@ -48,18 +55,23 @@ fn create_new_part(
     let mut value = Uint128::zero();
 
     for balence in account_balences {
-        if balence.denom == "uusdc" {
+        if &balence.denom == value_denom {
             value += balence.amount;
             continue;
         }
         let AmmSwapEstimationByDenomResponse { amount, .. } = querier
-            .amm_swap_estimation_by_denom(&balence, &balence.denom, "uusdc", &Decimal::zero())?;
+            .amm_swap_estimation_by_denom(
+                &balence,
+                &balence.denom,
+                value_denom,
+                &Decimal::zero(),
+            )?;
         value += amount.amount;
     }
 
     Ok(AccountValue {
         date,
-        account_value: coin(value.u128(), "uusdc"),
+        account_value: coin(value.u128(), value_denom),
     })
 }
 

--- a/contracts/account-history-contract/src/entry_point/instantiate.rs
+++ b/contracts/account-history-contract/src/entry_point/instantiate.rs
@@ -2,7 +2,7 @@ use elys_bindings::types::PageRequest;
 
 use super::*;
 use crate::msg::InstantiateMsg;
-use crate::states::{EXPIRATION, PAGINATION};
+use crate::states::{EXPIRATION, PAGINATION, VALUE_DENOM};
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -22,5 +22,8 @@ pub fn instantiate(
             count_total: false,
         },
     )?;
+    let querier = ElysQuerier::new(&deps.querier);
+    querier.asset_info(msg.value_denom.clone())?;
+    VALUE_DENOM.save(deps.storage, &msg.value_denom)?;
     Ok(Response::new())
 }

--- a/contracts/account-history-contract/src/entry_point/query.rs
+++ b/contracts/account-history-contract/src/entry_point/query.rs
@@ -8,10 +8,10 @@ pub fn query(deps: Deps<ElysQuery>, env: Env, msg: QueryMsg) -> StdResult<Binary
 
     match msg {
         UserValue { user_address } => to_json_binary(&user_value(deps, env.block, user_address)?),
-        Accounts {} => to_json_binary(&{
+        Accounts { pagination } => to_json_binary(&{
             let querrier = ElysQuerier::new(&deps.querier);
 
-            let resp = querrier.accounts(types::PageRequest::new(8))?;
+            let resp = querrier.accounts(pagination)?;
             resp
         }),
     }

--- a/contracts/account-history-contract/src/msg/instantiate.rs
+++ b/contracts/account-history-contract/src/msg/instantiate.rs
@@ -5,4 +5,5 @@ use cw_utils::Expiration;
 pub struct InstantiateMsg {
     pub limit: u64,
     pub expiration: Expiration,
+    pub value_denom: String,
 }

--- a/contracts/account-history-contract/src/msg/query.rs
+++ b/contracts/account-history-contract/src/msg/query.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use super::query_resp::UserValueResponse;
 use cosmwasm_schema::{cw_serde, QueryResponses};
+#[allow(unused_imports)]
 use elys_bindings::query_resp::AuthAddressesResponse;
 use elys_bindings::types::PageRequest;
 

--- a/contracts/account-history-contract/src/msg/query.rs
+++ b/contracts/account-history-contract/src/msg/query.rs
@@ -1,13 +1,14 @@
 #[allow(unused_imports)]
 use super::query_resp::UserValueResponse;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use elys_bindings::query_resp::AuthAccountsResponse;
+use elys_bindings::query_resp::AuthAddressesResponse;
+use elys_bindings::types::PageRequest;
 
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(UserValueResponse)]
     UserValue { user_address: String },
-    #[returns(AuthAccountsResponse)]
-    Accounts {},
+    #[returns(AuthAddressesResponse)]
+    Accounts { pagination: Option<PageRequest> },
 }

--- a/contracts/account-history-contract/src/states/mod.rs
+++ b/contracts/account-history-contract/src/states/mod.rs
@@ -1,7 +1,9 @@
 mod expiration;
 mod history;
 mod pagination;
+mod value_denom;
 
 pub use expiration::EXPIRATION;
 pub use history::HISTORY;
 pub use pagination::PAGINATION;
+pub use value_denom::VALUE_DENOM;

--- a/contracts/account-history-contract/src/states/value_denom.rs
+++ b/contracts/account-history-contract/src/states/value_denom.rs
@@ -1,0 +1,3 @@
+use cw_storage_plus::Item;
+
+pub const VALUE_DENOM: Item<String> = Item::new("value denom");

--- a/contracts/account-history-contract/src/tests.rs
+++ b/contracts/account-history-contract/src/tests.rs
@@ -28,6 +28,7 @@ fn history() {
     let init_msg = InstantiateMsg {
         limit: 2,
         expiration: Expiration::AtHeight(2),
+        value_denom: "usdc".to_string(),
     };
 
     let addr = app

--- a/contracts/account-history-contract/src/tests.rs
+++ b/contracts/account-history-contract/src/tests.rs
@@ -6,7 +6,7 @@ use crate::{entry_point::*, msg::SudoMsg};
 use cosmwasm_std::{coin, coins, Addr, Coin, Decimal};
 use cw_multi_test::{BankSudo, ContractWrapper, Executor, SudoMsg as AppSudo};
 use cw_utils::Expiration;
-use elys_bindings::types::Price;
+use elys_bindings::types::{OracleAssetInfo, Price};
 use elys_bindings_test::ElysApp;
 
 #[test]
@@ -18,9 +18,21 @@ fn history() {
         Price::new("uusdc", Decimal::from_str("1.0").unwrap()),
     ];
 
+    let infos = vec![OracleAssetInfo::new(
+        "uusdc".to_string(),
+        "UUSDC".to_string(),
+        "".to_string(),
+        "".to_string(),
+        2,
+    )];
+
     let mut app = ElysApp::new_with_wallets(wallets.clone());
-    app.init_modules(|router, _, store| router.custom.set_prices(store, &prices))
-        .unwrap();
+    app.init_modules(|router, _, store| {
+        router.custom.set_prices(store, &prices).unwrap();
+
+        router.custom.set_asset_infos(store, &infos)
+    })
+    .unwrap();
 
     let code = ContractWrapper::new(execute, instantiate, query).with_sudo(sudo);
     let code_id = app.store_code(Box::new(code));
@@ -28,7 +40,7 @@ fn history() {
     let init_msg = InstantiateMsg {
         limit: 2,
         expiration: Expiration::AtHeight(2),
-        value_denom: "usdc".to_string(),
+        value_denom: "uusdc".to_string(),
     };
 
     let addr = app

--- a/contracts/financial-snapshot-contract/src/bindings/query.rs
+++ b/contracts/financial-snapshot-contract/src/bindings/query.rs
@@ -1,20 +1,19 @@
 #[allow(unused_imports)]
 use super::query_resp::*;
 #[allow(unused_imports)]
-use crate::types::{BalanceBorrowed, QueryAprResponse, PageRequest};
+use crate::types::{BalanceBorrowed, PageRequest, QueryAprResponse};
 #[allow(unused_imports)]
 use elys_bindings::types::BalanceAvailable;
 
 #[allow(unused_imports)]
 use cosmwasm_schema::{cw_serde, QueryResponses};
 #[allow(unused_imports)]
-use cosmwasm_std::{CustomQuery, Decimal, Coin};
+use cosmwasm_std::{Coin, CustomQuery, Decimal};
 
 #[allow(unused_imports)]
 use crate::msg::query_resp::earn::QueryEarnPoolResponse;
-
+#[allow(unused_imports)]
 use elys_bindings::query_resp::QueryGetEntryResponse;
-
 
 #[cw_serde]
 #[derive(QueryResponses)]
@@ -22,7 +21,7 @@ pub enum ElysQuery {
     #[returns(BalanceAvailable)]
     AmmBalance { address: String, denom: String },
     #[returns(QueryDelegatorDelegationsResponse)]
-    CommitmentDelegations { delegator_address: String},
+    CommitmentDelegations { delegator_address: String },
     #[returns(QueryDelegatorUnbondingDelegationsResponse)]
     CommitmentUnbondingDelegations { delegator_address: String },
     #[returns(QueryDelegatorValidatorsResponse)]
@@ -42,75 +41,118 @@ pub enum ElysQuery {
     #[returns(QueryUnstakedPositionResponse)]
     CommitmentUnStakedPositions { delegator_address: String },
     #[returns(QueryVestingInfoResponse)]
-    CommitmentVestingInfo{ address: String },
+    CommitmentVestingInfo { address: String },
     #[returns(BalanceAvailable)]
-    CommitmentRewardsSubBucketBalanceOfDenom{ address: String, denom: String, program: i32},
+    CommitmentRewardsSubBucketBalanceOfDenom {
+        address: String,
+        denom: String,
+        program: i32,
+    },
     #[returns(QueryAprResponse)]
-    IncentiveApr{withdraw_type: i32, denom: String},
+    IncentiveApr { withdraw_type: i32, denom: String },
     #[returns(Decimal)]
-    AmmPriceByDenom{token_in: Coin, discount: Decimal},
+    AmmPriceByDenom { token_in: Coin, discount: Decimal },
     #[returns(QueryGetPriceResponse)]
-    OraclePrice{asset: String, source: String, timestamp: u64},
+    OraclePrice {
+        asset: String,
+        source: String,
+        timestamp: u64,
+    },
     #[returns(QueryEarnPoolResponse)]
-    AmmEarnMiningPoolAll{pool_ids: Option<Vec<u64>>, filter_type: i32, pagination: Option<PageRequest>},
+    AmmEarnMiningPoolAll {
+        pool_ids: Option<Vec<u64>>,
+        filter_type: i32,
+        pagination: Option<PageRequest>,
+    },
     #[returns(QueryGetEntryResponse)]
-    AssetProfileEntry{base_denom: String}
+    AssetProfileEntry { base_denom: String },
 }
 
 impl CustomQuery for ElysQuery {}
 impl ElysQuery {
     pub fn get_balance(address: String, denom: String) -> Self {
-        ElysQuery::AmmBalance{ address, denom }
+        ElysQuery::AmmBalance { address, denom }
     }
     pub fn get_delegations(delegator_addr: String) -> Self {
-        ElysQuery::CommitmentDelegations{ delegator_address: delegator_addr }
+        ElysQuery::CommitmentDelegations {
+            delegator_address: delegator_addr,
+        }
     }
     pub fn get_unbonding_delegations(delegator_addr: String) -> Self {
-        ElysQuery::CommitmentUnbondingDelegations{ delegator_address: delegator_addr }
+        ElysQuery::CommitmentUnbondingDelegations {
+            delegator_address: delegator_addr,
+        }
     }
     pub fn get_all_validators() -> Self {
-        ElysQuery::CommitmentAllValidators{ delegator_address: "".to_string() }
+        ElysQuery::CommitmentAllValidators {
+            delegator_address: "".to_string(),
+        }
     }
     pub fn get_delegator_validators(delegator_addr: String) -> Self {
-        ElysQuery::CommitmentDelegatorValidators{ delegator_address: delegator_addr }
+        ElysQuery::CommitmentDelegatorValidators {
+            delegator_address: delegator_addr,
+        }
     }
     pub fn get_commitments(address: String) -> Self {
-        ElysQuery::CommitmentShowCommitments{ creator: address }
+        ElysQuery::CommitmentShowCommitments { creator: address }
     }
     pub fn get_staked_balance(address: String, denom: String) -> Self {
-        ElysQuery::CommitmentStakedBalanceOfDenom{ address, denom }
+        ElysQuery::CommitmentStakedBalanceOfDenom { address, denom }
     }
     pub fn get_rewards_balance(address: String, denom: String) -> Self {
-        ElysQuery::CommitmentRewardsBalanceOfDenom{ address, denom }
+        ElysQuery::CommitmentRewardsBalanceOfDenom { address, denom }
     }
     pub fn get_borrowed_balance(address: String) -> Self {
-        ElysQuery::StableStakeBalanceOfBorrow{ address }
+        ElysQuery::StableStakeBalanceOfBorrow { address }
     }
     pub fn get_staked_positions(delegator_addr: String) -> Self {
-        ElysQuery::CommitmentStakedPositions{ delegator_address: delegator_addr }
+        ElysQuery::CommitmentStakedPositions {
+            delegator_address: delegator_addr,
+        }
     }
     pub fn get_unstaked_positions(delegator_addr: String) -> Self {
-        ElysQuery::CommitmentUnStakedPositions{ delegator_address: delegator_addr }
+        ElysQuery::CommitmentUnStakedPositions {
+            delegator_address: delegator_addr,
+        }
     }
     pub fn get_vesting_info(address: String) -> Self {
-        ElysQuery::CommitmentVestingInfo{ address }
+        ElysQuery::CommitmentVestingInfo { address }
     }
     pub fn get_sub_bucket_rewards_balance(address: String, denom: String, program: i32) -> Self {
-        ElysQuery::CommitmentRewardsSubBucketBalanceOfDenom{ address, denom, program }
+        ElysQuery::CommitmentRewardsSubBucketBalanceOfDenom {
+            address,
+            denom,
+            program,
+        }
     }
     pub fn get_incentive_apr(program: i32, denom: String) -> Self {
-        ElysQuery::IncentiveApr{ withdraw_type: program, denom }
+        ElysQuery::IncentiveApr {
+            withdraw_type: program,
+            denom,
+        }
     }
     pub fn get_amm_price_by_denom(token_in: Coin, discount: Decimal) -> Self {
-        ElysQuery::AmmPriceByDenom{ token_in, discount }
+        ElysQuery::AmmPriceByDenom { token_in, discount }
     }
     pub fn get_oracle_price(asset: String, source: String, timestamp: u64) -> Self {
-        ElysQuery::OraclePrice{ asset, source, timestamp }
+        ElysQuery::OraclePrice {
+            asset,
+            source,
+            timestamp,
+        }
     }
-    pub fn get_all_pools(pool_ids: Option<Vec<u64>>, filter_type: i32, pagination: Option<PageRequest>) -> Self {
-        ElysQuery::AmmEarnMiningPoolAll{ pool_ids, filter_type, pagination }
+    pub fn get_all_pools(
+        pool_ids: Option<Vec<u64>>,
+        filter_type: i32,
+        pagination: Option<PageRequest>,
+    ) -> Self {
+        ElysQuery::AmmEarnMiningPoolAll {
+            pool_ids,
+            filter_type,
+            pagination,
+        }
     }
     pub fn get_asset_profile(base_denom: String) -> Self {
-        ElysQuery::AssetProfileEntry{ base_denom }
+        ElysQuery::AssetProfileEntry { base_denom }
     }
 }

--- a/contracts/financial-snapshot-contract/src/tests/mod.rs
+++ b/contracts/financial-snapshot-contract/src/tests/mod.rs
@@ -1,14 +1,3 @@
-use crate::{
-    entry_point::{query},
-    msg::*,
-    ContractError,
-};
-
-mod get_portfolio {
-    use super::*;
-    use cosmwasm_std::{Binary, StdError};
-}
-
 pub use mock::instantiate::*;
 mod mock {
     #[allow(dead_code, unused)]


### PR DESCRIPTION
 - [x] Integrate the new `Auth accounts` query and response.
 - [x] Update the `account history contract` usage of the new `Auth accounts` query.
 - [x] Add a new variable to the initialization of the contract for setting the `value_denom`, which is the field that will contain          the `uusdc` IBC denom.
 - [x] Remove the warning from the `financial-snapshot-contract`.