### PR TITLE
chore: add rewards api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "cw-utils",
  "elys-bindings",
  "elys-bindings-test",
+ "financial_snapshot_contract",
  "schemars",
  "serde",
  "serde_json",
@@ -33,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "base16ct"
@@ -45,9 +46,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
@@ -111,9 +112,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bb3c77c3b7ce472056968c745eb501c440fbc07be5004eba02782c35bfbbe3"
+checksum = "ad24bc9dae9aac5dc124b4560e3f7678729d701f1bf3cb11140703d91f247d31"
 dependencies = [
  "digest 0.10.7",
  "ecdsa",
@@ -125,18 +126,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea73e9162e6efde00018d55ed0061e93a108b5d6ec4548b4f8ce3c706249687"
+checksum = "ca65635b768406eabdd28ba015cc3f2f863ca5a2677a7dc4c237b8ee1298efb3"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df41ea55f2946b6b43579659eec048cc2f66e8c8e2e3652fc5e5e476f673856"
+checksum = "77e2a6ce6dbcad572495fd9d9c1072793fe682aebfcc09752c3b0de3fa1814d7"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -147,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43609e92ce1b9368aa951b334dd354a2d0dd4d484931a5f83ae10e12a26c8ba9"
+checksum = "904408dc6d73fd1d535c764a55370803cccf6b9be5af7423c4db8967058673f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -158,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d6864742e3a7662d024b51a94ea81c9af21db6faea2f9a6d2232bb97c6e53e"
+checksum = "1ed4564772e5d779235f2d7353e3d66e37793065c3a5155a2978256bf4c5b7d5"
 dependencies = [
  "base64",
  "bech32",
@@ -190,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -468,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -529,9 +530,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "k256"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -543,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "once_cell"
@@ -571,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -603,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -681,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
@@ -699,13 +700,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -721,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -799,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -810,22 +811,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/contracts/account-history-contract/Cargo.toml
+++ b/contracts/account-history-contract/Cargo.toml
@@ -18,9 +18,13 @@ elys-bindings = { path = "../../bindings" }
 trade_shield_contract = { path = "../trade-shield-contract", features = [
     "msg_only",
 ] }
+financial_snapshot_contract = { path = "../financial-snapshot-contract", features = [
+    "msg_only",
+] }
 
 [dev-dependencies]
 trade_shield_contract = { path = "../trade-shield-contract", features = [] }
+financial_snapshot_contract = { path = "../financial-snapshot-contract", features = [] }
 cw-multi-test = "0.13.4"
 serde_json = "1.0.107"
 elys-bindings = { path = "../../bindings", features = ["testing"] }

--- a/contracts/account-history-contract/src/action/mod.rs
+++ b/contracts/account-history-contract/src/action/mod.rs
@@ -10,5 +10,7 @@ pub mod sudo {
 
 pub mod query {
     mod user_value;
+    mod user_rewards;
     pub use user_value::user_value;
+    pub use user_rewards::user_rewards;
 }

--- a/contracts/account-history-contract/src/action/query/user_rewards.rs
+++ b/contracts/account-history-contract/src/action/query/user_rewards.rs
@@ -1,0 +1,20 @@
+use crate::{
+    states::HISTORY,
+    msg::query_resp::UserRewardsResponse,};
+use elys_bindings::ElysQuery;
+use cosmwasm_std::{Deps, StdError, StdResult};
+
+pub fn user_rewards(
+    deps: Deps<ElysQuery>,
+    user_address: String,
+) -> StdResult<UserRewardsResponse> {
+    let user_history: Vec<crate::types::AccountSnapshot> = match HISTORY.may_load(deps.storage, &user_address)? {
+        Some(history) => history,
+        None => return Err(StdError::not_found(format!("user :{user_address}"))),
+    };
+
+    let latest_snapshot = user_history.last().unwrap();
+    Ok(UserRewardsResponse {
+        rewards: latest_snapshot.rewards.to_owned(),
+    })
+}

--- a/contracts/account-history-contract/src/entry_point/instantiate.rs
+++ b/contracts/account-history-contract/src/entry_point/instantiate.rs
@@ -2,7 +2,7 @@ use elys_bindings::types::PageRequest;
 
 use super::*;
 use crate::msg::InstantiateMsg;
-use crate::states::{EXPIRATION, PAGINATION, VALUE_DENOM, TRADE_SHIELD_ADDRESS};
+use crate::states::{EXPIRATION, PAGINATION, VALUE_DENOM, TRADE_SHIELD_ADDRESS, FINANCIAL_SNAPSHOT_ADDRESS};
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -26,5 +26,6 @@ pub fn instantiate(
     querier.asset_info(msg.value_denom.clone())?;
     VALUE_DENOM.save(deps.storage, &msg.value_denom)?;
     TRADE_SHIELD_ADDRESS.save(deps.storage, &msg.trade_shield_address)?;
+    FINANCIAL_SNAPSHOT_ADDRESS.save(deps.storage, &msg.financial_snapshot_address)?;
     Ok(Response::new())
 }

--- a/contracts/account-history-contract/src/entry_point/query.rs
+++ b/contracts/account-history-contract/src/entry_point/query.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::action::query::user_value;
+use crate::action::query::*;
 use msg::QueryMsg;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -14,5 +14,6 @@ pub fn query(deps: Deps<ElysQuery>, env: Env, msg: QueryMsg) -> StdResult<Binary
             let resp = querrier.accounts(pagination)?;
             resp
         }),
+        UserRewards { user_address } => Ok(to_json_binary(&user_rewards(deps, user_address)?)?),
     }
 }

--- a/contracts/account-history-contract/src/msg/instantiate.rs
+++ b/contracts/account-history-contract/src/msg/instantiate.rs
@@ -6,5 +6,6 @@ pub struct InstantiateMsg {
     pub limit: u64,
     pub expiration: Expiration,
     pub value_denom: String,
-    pub trade_shield_address: String
+    pub trade_shield_address: String,
+    pub financial_snapshot_address: String
 }

--- a/contracts/account-history-contract/src/msg/mod.rs
+++ b/contracts/account-history-contract/src/msg/mod.rs
@@ -9,6 +9,9 @@ pub use query::QueryMsg;
 pub use sudo::SudoMsg;
 
 pub mod query_resp {
+    mod user_rewards_response;
     mod user_value_response;
+
     pub use user_value_response::UserValueResponse;
+    pub use user_rewards_response::UserRewardsResponse;
 }

--- a/contracts/account-history-contract/src/msg/query.rs
+++ b/contracts/account-history-contract/src/msg/query.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use super::query_resp::UserValueResponse;
+use super::query_resp::{UserValueResponse, UserRewardsResponse};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 #[allow(unused_imports)]
 use elys_bindings::query_resp::AuthAddressesResponse;
@@ -12,4 +12,6 @@ pub enum QueryMsg {
     UserValue { user_address: String },
     #[returns(AuthAddressesResponse)]
     Accounts { pagination: Option<PageRequest> },
+    #[returns(UserRewardsResponse)]
+    UserRewards { user_address: String },
 }

--- a/contracts/account-history-contract/src/msg/query_resp/user_rewards_response.rs
+++ b/contracts/account-history-contract/src/msg/query_resp/user_rewards_response.rs
@@ -1,0 +1,7 @@
+use crate::types::Rewards;
+use cosmwasm_schema::cw_serde;
+
+#[cw_serde]
+pub struct UserRewardsResponse {
+    pub rewards: Rewards,
+}

--- a/contracts/account-history-contract/src/states/financial_snapshot_address.rs
+++ b/contracts/account-history-contract/src/states/financial_snapshot_address.rs
@@ -1,0 +1,3 @@
+use cw_storage_plus::Item;
+
+pub const FINANCIAL_SNAPSHOT_ADDRESS : Item<String> = Item::new("financial_snapshot_address");

--- a/contracts/account-history-contract/src/states/mod.rs
+++ b/contracts/account-history-contract/src/states/mod.rs
@@ -3,9 +3,11 @@ mod history;
 mod pagination;
 mod value_denom;
 mod trade_shield_address;
+mod financial_snapshot_address;
 
 pub use expiration::EXPIRATION;
 pub use history::HISTORY;
 pub use pagination::PAGINATION;
 pub use value_denom::VALUE_DENOM;
 pub use trade_shield_address::TRADE_SHIELD_ADDRESS;
+pub use financial_snapshot_address::FINANCIAL_SNAPSHOT_ADDRESS;

--- a/contracts/account-history-contract/src/types/account_snapshot.rs
+++ b/contracts/account-history-contract/src/types/account_snapshot.rs
@@ -1,6 +1,14 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Coin;
+use cosmwasm_std::{Coin, Decimal, Uint128};
 use cw_utils::Expiration;
+
+#[cw_serde]
+pub struct Rewards {
+    pub usdc: Decimal, // in usd dollar
+    pub eden: Decimal, // in usd dollar
+    pub edenb: Uint128, // eden boost doens't have price
+    pub other: Decimal, // in usd dollar
+}
 
 #[cw_serde]
 pub struct AccountSnapshot {
@@ -9,4 +17,5 @@ pub struct AccountSnapshot {
     pub locked_value: Coin,
     pub account_assets: Vec<Coin>,
     pub locked_asset : Vec<Coin>,
+    pub rewards: Rewards,
 }

--- a/contracts/account-history-contract/src/types/mod.rs
+++ b/contracts/account-history-contract/src/types/mod.rs
@@ -3,3 +3,4 @@ mod account_snapshot;
 
 pub use account_value::AccountValue;
 pub use account_snapshot::AccountSnapshot;
+pub use account_snapshot::Rewards;

--- a/contracts/financial-snapshot-contract/Cargo.toml
+++ b/contracts/financial-snapshot-contract/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+msg_only = []
+
 [dependencies]
 cosmwasm-std = { version = "1.1.4", features = ["staking"] }
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/financial-snapshot-contract/src/lib.rs
+++ b/contracts/financial-snapshot-contract/src/lib.rs
@@ -2,10 +2,9 @@ pub mod entry_point;
 pub mod msg;
 pub mod types;
 pub use error::ContractError;
-
 mod error;
 mod action;
-mod bindings;
+pub mod bindings;
 use bindings::query::ElysQuery;
 mod states;
 


### PR DESCRIPTION
- Add rewards to account snapshot structure
- Add a function to get rewards and update account function and include rewards in account history snapshot.
- Add query to return user rewards.
- Add msg_only feature to financial snapshot contract cargo in order to make it available to call financial contract from account.
- Update instantiate function of account history contract to set financial contract address
- Add a state storage for storing financial contract address.