### PR TITLE
chore: fix to add record all the time

### DIFF
--- a/contracts/account-history-contract/src/action/sudo/update_account.rs
+++ b/contracts/account-history-contract/src/action/sudo/update_account.rs
@@ -203,21 +203,18 @@ fn create_new_part(
         value_denom,
     );
 
-    Ok(if total_liquid_asset_balance.amount.is_zero() {
-        None
-    } else {
-        Some(AccountSnapshot {
-            date,
-            total_liquid_asset_balance,
-            total_available_balance,
-            total_in_orders_balance,
-            available_asset_balance,
-            in_orders_asset_balance,
-            total_value_per_asset,
-            total_staked_asset_balance: staked_assets_resp.total_balance,
-            staked_assets: staked_assets_resp.staked_assets,
-        })
-    })
+    // Adds the records all the time as we should return data to the FE even if it is 0 balanced.
+    Ok(Some(AccountSnapshot {
+        date,
+        total_liquid_asset_balance,
+        total_available_balance,
+        total_in_orders_balance,
+        available_asset_balance,
+        in_orders_asset_balance,
+        total_value_per_asset,
+        total_staked_asset_balance: staked_assets_resp.total_balance,
+        staked_assets: staked_assets_resp.staked_assets,
+    }))
 }
 
 fn update_history(


### PR DESCRIPTION
Change to add the record all the time even if it is 0 balanced. Because we should remove the criteria in order to return data to FE even if he is 0 balance. If the snapshot only store balanced data, we may not return the empty balanced account the result.