### PR TITLE
Fix/margin order check

### DIFF
--- a/contracts/trade-shield-contract/src/action/sudo/process_orders.rs
+++ b/contracts/trade-shield-contract/src/action/sudo/process_orders.rs
@@ -69,6 +69,7 @@ pub fn process_orders(
         ) {
             Ok(amm_swap_estimation) => amm_swap_estimation,
             Err(_) => {
+                println!("amm_swap_estimation_by_denom error");
                 order.status = Status::Canceled;
                 PENDING_MARGIN_ORDER.remove(deps.storage, order.order_id);
                 MARGIN_ORDER.save(deps.storage, order.order_id, &order)?;
@@ -86,13 +87,15 @@ pub fn process_orders(
                 Ok(mtp) => match mtp.mtp {
                     Some(_) => {}
                     None => {
+                        println!("mtp.mtp is None");
                         order.status = Status::Canceled;
                         PENDING_MARGIN_ORDER.remove(deps.storage, order.order_id);
                         MARGIN_ORDER.save(deps.storage, order.order_id, &order)?;
                         continue;
                     }
                 },
-                Err(_) => {
+                Err(e) => {
+                    println!("mtp error {e:?}");
                     order.status = Status::Canceled;
                     PENDING_MARGIN_ORDER.remove(deps.storage, order.order_id);
                     MARGIN_ORDER.save(deps.storage, order.order_id, &order)?;
@@ -202,6 +205,9 @@ fn check_margin_order(
     };
 
     let market_price = amm_swap_estimation.spot_price;
+
+    println!("market_price:{market_price:?}");
+    println!("order_spot_price:{order_spot_price:?}");
 
     match (&order.order_type, &order.position) {
         (MarginOrderType::LimitOpen, MarginPosition::Long) => market_price <= order_spot_price,

--- a/contracts/trade-shield-contract/src/action/sudo/process_orders.rs
+++ b/contracts/trade-shield-contract/src/action/sudo/process_orders.rs
@@ -24,14 +24,28 @@ pub fn process_orders(
 
     let querier = ElysQuerier::new(&deps.querier);
     let mut submsgs: Vec<SubMsg<ElysMsg>> = vec![];
+    let mut bank_msgs: Vec<BankMsg> = vec![];
 
     for spot_order in spot_orders.iter() {
-        let amm_swap_estimation = querier.amm_swap_estimation_by_denom(
+        let amm_swap_estimation = match querier.amm_swap_estimation_by_denom(
             &spot_order.order_amount,
             &spot_order.order_amount.denom,
             &spot_order.order_target_denom,
             &Decimal::zero(),
-        )?;
+        ) {
+            Ok(amm_swap_estimation) => amm_swap_estimation,
+            Err(_) => {
+                let mut order = spot_order.to_owned();
+                order.status = Status::Canceled;
+                bank_msgs.push(BankMsg::Send {
+                    to_address: order.owner_address.to_string(),
+                    amount: vec![order.order_amount.clone()],
+                });
+                PENDING_SPOT_ORDER.remove(deps.storage, order.order_id);
+                SPOT_ORDER.save(deps.storage, order.order_id, &order)?;
+                continue;
+            }
+        };
 
         if check_spot_order(&spot_order, &amm_swap_estimation) {
             process_spot_order(
@@ -46,12 +60,46 @@ pub fn process_orders(
     }
 
     for margin_order in margin_orders.iter() {
-        let amm_swap_estimation = querier.amm_swap_estimation_by_denom(
+        let mut order = margin_order.to_owned();
+        let amm_swap_estimation = match querier.amm_swap_estimation_by_denom(
             &margin_order.collateral,
             &margin_order.collateral.denom,
             &margin_order.trading_asset,
             &Decimal::zero(),
-        )?;
+        ) {
+            Ok(amm_swap_estimation) => amm_swap_estimation,
+            Err(_) => {
+                order.status = Status::Canceled;
+                PENDING_MARGIN_ORDER.remove(deps.storage, order.order_id);
+                MARGIN_ORDER.save(deps.storage, order.order_id, &order)?;
+                if order.order_type == MarginOrderType::LimitOpen {
+                    bank_msgs.push(BankMsg::Send {
+                        to_address: order.owner.to_string(),
+                        amount: vec![order.collateral.clone()],
+                    });
+                }
+                continue;
+            }
+        };
+        if order.order_type != MarginOrderType::LimitOpen {
+            match querier.mtp(order.owner.clone(), order.position_id.clone().unwrap()) {
+                Ok(mtp) => match mtp.mtp {
+                    Some(_) => {}
+                    None => {
+                        order.status = Status::Canceled;
+                        PENDING_MARGIN_ORDER.remove(deps.storage, order.order_id);
+                        MARGIN_ORDER.save(deps.storage, order.order_id, &order)?;
+                        continue;
+                    }
+                },
+                Err(_) => {
+                    order.status = Status::Canceled;
+                    PENDING_MARGIN_ORDER.remove(deps.storage, order.order_id);
+                    MARGIN_ORDER.save(deps.storage, order.order_id, &order)?;
+                    continue;
+                }
+            };
+        }
 
         if check_margin_order(&margin_order, amm_swap_estimation) {
             process_margin_order(
@@ -153,28 +201,15 @@ fn check_margin_order(
         false => Decimal::one().div(trigger_price.rate),
     };
 
-    let token_swap_estimation = amm_swap_estimation.amount.amount;
-    let order_estimation = order_spot_price * order.collateral.amount;
+    let market_price = amm_swap_estimation.spot_price;
 
     match (&order.order_type, &order.position) {
-        (MarginOrderType::LimitOpen, MarginPosition::Long) => {
-            token_swap_estimation <= order_estimation
-        }
-        (MarginOrderType::LimitOpen, MarginPosition::Short) => {
-            token_swap_estimation >= order_estimation
-        }
-        (MarginOrderType::LimitClose, MarginPosition::Long) => {
-            token_swap_estimation >= order_estimation
-        }
-        (MarginOrderType::LimitClose, MarginPosition::Short) => {
-            token_swap_estimation <= order_estimation
-        }
-        (MarginOrderType::StopLoss, MarginPosition::Long) => {
-            token_swap_estimation <= order_estimation
-        }
-        (MarginOrderType::StopLoss, MarginPosition::Short) => {
-            token_swap_estimation >= order_estimation
-        }
+        (MarginOrderType::LimitOpen, MarginPosition::Long) => market_price <= order_spot_price,
+        (MarginOrderType::LimitOpen, MarginPosition::Short) => market_price >= order_spot_price,
+        (MarginOrderType::LimitClose, MarginPosition::Long) => market_price >= order_spot_price,
+        (MarginOrderType::LimitClose, MarginPosition::Short) => market_price <= order_spot_price,
+        (MarginOrderType::StopLoss, MarginPosition::Long) => market_price <= order_spot_price,
+        (MarginOrderType::StopLoss, MarginPosition::Short) => market_price >= order_spot_price,
         _ => false,
     }
 }

--- a/contracts/trade-shield-contract/src/action/sudo/process_orders.rs
+++ b/contracts/trade-shield-contract/src/action/sudo/process_orders.rs
@@ -69,7 +69,6 @@ pub fn process_orders(
         ) {
             Ok(amm_swap_estimation) => amm_swap_estimation,
             Err(_) => {
-                println!("amm_swap_estimation_by_denom error");
                 order.status = Status::Canceled;
                 PENDING_MARGIN_ORDER.remove(deps.storage, order.order_id);
                 MARGIN_ORDER.save(deps.storage, order.order_id, &order)?;
@@ -87,7 +86,6 @@ pub fn process_orders(
                 Ok(mtp) => match mtp.mtp {
                     Some(_) => {}
                     None => {
-                        println!("mtp.mtp is None");
                         order.status = Status::Canceled;
                         PENDING_MARGIN_ORDER.remove(deps.storage, order.order_id);
                         MARGIN_ORDER.save(deps.storage, order.order_id, &order)?;
@@ -95,7 +93,6 @@ pub fn process_orders(
                     }
                 },
                 Err(e) => {
-                    println!("mtp error {e:?}");
                     order.status = Status::Canceled;
                     PENDING_MARGIN_ORDER.remove(deps.storage, order.order_id);
                     MARGIN_ORDER.save(deps.storage, order.order_id, &order)?;
@@ -205,9 +202,6 @@ fn check_margin_order(
     };
 
     let market_price = amm_swap_estimation.spot_price;
-
-    println!("market_price:{market_price:?}");
-    println!("order_spot_price:{order_spot_price:?}");
 
     match (&order.order_type, &order.position) {
         (MarginOrderType::LimitOpen, MarginPosition::Long) => market_price <= order_spot_price,

--- a/contracts/trade-shield-contract/src/action/sudo/process_orders.rs
+++ b/contracts/trade-shield-contract/src/action/sudo/process_orders.rs
@@ -192,14 +192,14 @@ fn check_spot_order(
         false => Decimal::one().div(order.order_price.rate),
     };
 
-    let order_token_out = order_spot_price * order.order_amount.amount;
+    let market_price = amm_swap_estimation.spot_price;
 
     match order.order_type {
-        SpotOrderType::LimitBuy => order_token_out <= amm_swap_estimation.amount.amount,
+        SpotOrderType::LimitBuy => market_price <= order_spot_price,
 
-        SpotOrderType::LimitSell => order_token_out <= amm_swap_estimation.amount.amount,
+        SpotOrderType::LimitSell => market_price >= order_spot_price,
 
-        SpotOrderType::StopLoss => order_token_out >= amm_swap_estimation.amount.amount,
+        SpotOrderType::StopLoss => market_price <= order_spot_price,
         _ => false,
     }
 }
@@ -267,4 +267,95 @@ fn calculate_token_out_min_amount(order: &SpotOrder) -> Int128 {
     };
 
     Int128::new((amount.u128()) as i128)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use cosmwasm_std::{coin, Addr, SignedDecimal, Timestamp};
+
+    use super::*;
+
+    #[test]
+    fn test_check_spot_order_limit_buy() {
+        // Arrange
+        let spot_order = SpotOrder {
+            order_type: SpotOrderType::LimitBuy,
+            order_id: 1,
+            order_price: OrderPrice {
+                base_denom: "uatom".to_string(),
+                quote_denom: "usdc".to_string(),
+                rate: Decimal::from_str("9.0").unwrap(),
+            },
+            order_amount: coin(1000000, "usdc"),
+
+            owner_address: Addr::unchecked("elysd"),
+            order_target_denom: "uatom".to_string(),
+            status: Status::Pending,
+            date: Date {
+                height: 5,
+                time: Timestamp::from_seconds(5),
+            },
+            // Initialize the rest of the SpotOrder fields here
+        };
+        let amm_swap_estimation = AmmSwapEstimationByDenomResponse {
+            spot_price: Decimal::from_str("9.29").unwrap(),
+            in_route: None,
+            out_route: None,
+            amount: coin(1000000, "uatom"),
+            swap_fee: SignedDecimal::zero(),
+            discount: SignedDecimal::zero(),
+            available_liquidity: coin(1000000, "uatom"),
+            weight_balance_ratio: SignedDecimal::zero(),
+            price_impact: SignedDecimal::zero(),
+        };
+
+        // Act
+        let result = check_spot_order(&spot_order, &amm_swap_estimation);
+
+        // Assert
+        assert_eq!(result, false); // Change as needed
+    }
+
+    #[test]
+    fn test_check_spot_order_limit_sell() {
+        // Arrange
+        let spot_order = SpotOrder {
+            order_type: SpotOrderType::LimitSell,
+            order_id: 1,
+            order_price: OrderPrice {
+                base_denom: "uatom".to_string(),
+                quote_denom: "usdc".to_string(),
+                rate: Decimal::from_str("10.0").unwrap(),
+            },
+            order_amount: coin(1000000, "uatom"),
+
+            owner_address: Addr::unchecked("elysd"),
+            order_target_denom: "usdc".to_string(),
+            status: Status::Pending,
+            date: Date {
+                height: 5,
+                time: Timestamp::from_seconds(5),
+            },
+            // Initialize the rest of the SpotOrder fields here
+        };
+        let amm_swap_estimation = AmmSwapEstimationByDenomResponse {
+            spot_price: Decimal::from_str("9.29").unwrap(),
+            in_route: None,
+            out_route: None,
+            amount: coin(1000000, "usdc"),
+            swap_fee: SignedDecimal::zero(),
+            discount: SignedDecimal::zero(),
+            available_liquidity: coin(1000000, "usdc"),
+            weight_balance_ratio: SignedDecimal::zero(),
+            price_impact: SignedDecimal::zero(),
+        };
+
+        // Act
+        let result = check_spot_order(&spot_order, &amm_swap_estimation);
+
+        // Assert
+        assert_eq!(result, false); // Change as needed
+    }
 }

--- a/contracts/trade-shield-contract/src/tests/process_margin_order/process_limit_open.rs
+++ b/contracts/trade-shield-contract/src/tests/process_margin_order/process_limit_open.rs
@@ -14,7 +14,7 @@ fn successful_process_limit_buy_order() {
         Price::new("usdc", Decimal::from_atomics(Uint128::new(1), 0).unwrap()),
     ];
     let prices_at_t1 = vec![
-        Price::new("ubtc", Decimal::from_atomics(Uint128::new(40), 0).unwrap()),
+        Price::new("ubtc", Decimal::from_atomics(Uint128::new(30), 0).unwrap()),
         Price::new("usdc", Decimal::from_atomics(Uint128::new(1), 0).unwrap()),
     ];
 

--- a/contracts/trade-shield-contract/src/tests/process_margin_order/process_order_close.rs
+++ b/contracts/trade-shield-contract/src/tests/process_margin_order/process_order_close.rs
@@ -12,7 +12,7 @@ fn successful_process_limit_buy_order() {
         Price::new("usdc", Decimal::from_atomics(Uint128::new(1), 0).unwrap()),
     ];
     let prices_at_t1 = vec![
-        Price::new("ubtc", Decimal::from_atomics(Uint128::new(40), 0).unwrap()),
+        Price::new("ubtc", Decimal::from_atomics(Uint128::new(30), 0).unwrap()),
         Price::new("usdc", Decimal::from_atomics(Uint128::new(1), 0).unwrap()),
     ];
 
@@ -62,13 +62,6 @@ fn successful_process_limit_buy_order() {
         )
         .unwrap();
 
-    // Set the initial ubtc and USDC prices.
-    app.init_modules(|router, _, store| router.custom.set_prices(store, &prices_at_t0))
-        .unwrap();
-
-    // Execute the order processing.
-    app.wasm_sudo(addr.clone(), &sudo_msg).unwrap();
-
     app.init_modules(|router, _, storage| {
         router.custom.set_mtp(
             storage,
@@ -104,6 +97,13 @@ fn successful_process_limit_buy_order() {
         )
     })
     .unwrap();
+
+    // Set the initial ubtc and USDC prices.
+    app.init_modules(|router, _, store| router.custom.set_prices(store, &prices_at_t0))
+        .unwrap();
+
+    // Execute the order processing.
+    app.wasm_sudo(addr.clone(), &sudo_msg).unwrap();
 
     let last_module =
         app.init_modules(|router, _, store| router.custom.get_last_module(store).unwrap());


### PR DESCRIPTION

```rust
 match (&order.order_type, &order.position) {
        (MarginOrderType::LimitOpen, MarginPosition::Long) => market_price <= order_spot_price,
        (MarginOrderType::LimitOpen, MarginPosition::Short) => market_price >= order_spot_price,
        (MarginOrderType::LimitClose, MarginPosition::Long) => market_price >= order_spot_price,
        (MarginOrderType::LimitClose, MarginPosition::Short) => market_price <= order_spot_price,
        (MarginOrderType::StopLoss, MarginPosition::Long) => market_price <= order_spot_price,
        (MarginOrderType::StopLoss, MarginPosition::Short) => market_price >= order_spot_price,
        _ => false,  //market order case
    }

```

@cosmic-vagabond  can you confirm that control flow check