### PR TITLE
feat: add the new field from perpetual open estimation and fix: tests…

### DIFF
--- a/bindings-test/src/multitest.rs
+++ b/bindings-test/src/multitest.rs
@@ -20,17 +20,10 @@ use elys_bindings::{
         PerpetualOpenResponse,
     },
     query_resp::{
-        AmmSwapEstimationByDenomResponse, AmmSwapEstimationResponse, AuthAddressesResponse,
-        BalanceBorrowed, Commitments, Entry, OracleAssetInfoResponse,
-        PerpetualGetPositionsForAddressResponse, PerpetualMtpResponse,
-        PerpetualOpenEstimationResponse, PerpetualQueryPositionsResponse, QueryAprResponse,
-        QueryGetEntryAllResponse, QueryGetEntryResponse, QueryGetPriceResponse,
-        QueryShowCommitmentsResponse, QueryStakedPositionResponse, QueryUnstakedPositionResponse,
-        QueryVestingInfoResponse, StableStakeParamsData, StableStakeParamsResp,
+        AmmSwapEstimationByDenomResponse, AmmSwapEstimationResponse, AuthAddressesResponse, BalanceBorrowed, Commitments, Entry, OracleAssetInfoResponse, PerpetualGetPositionsForAddressResponse, PerpetualMtpResponse, PerpetualOpenEstimationRawResponse, PerpetualQueryPositionsResponse, QueryAprResponse, QueryGetEntryAllResponse, QueryGetEntryResponse, QueryGetPriceResponse, QueryShowCommitmentsResponse, QueryStakedPositionResponse, QueryUnstakedPositionResponse, QueryVestingInfoResponse, StableStakeParamsData, StableStakeParamsResp
     },
     types::{
-        BalanceAvailable, Mtp, OracleAssetInfo, PageResponse, Price, SwapAmountInRoute,
-        SwapAmountOutRoute,
+        BalanceAvailable, Mtp, OracleAssetInfo, PageResponse, Price, SwapAmountInRoute, SwapAmountOutRoute
     },
     ElysMsg, ElysQuery,
 };
@@ -286,25 +279,26 @@ impl Module for ElysModule {
                 take_profit_price,
                 discount,
             } => {
-                return Ok(to_json_binary(&PerpetualOpenEstimationResponse {
+                return Ok(to_json_binary(&PerpetualOpenEstimationRawResponse {
                     position,
                     min_collateral: coin(0, &collateral.denom),
                     available_liquidity: coin(99999999, &trading_asset),
-                    leverage,
+                    leverage: leverage.to_string(),
                     collateral,
                     trading_asset,
-                    discount,
-                    valid_collateral: true,
+                    discount: discount.to_string(),
+                    valid_collateral: Some(true),
                     position_size: coin(1, "btc"),
-                    swap_fee: Decimal::zero(),
-                    open_price: Decimal::zero(),
-                    take_profit_price,
-                    liquidation_price: Decimal::zero(),
+                    swap_fee: Decimal::zero().to_string(),
+                    open_price: Decimal::zero().to_string(),
+                    take_profit_price : take_profit_price.to_string(),
+                    liquidation_price: Decimal::zero().to_string(),
                     estimated_pnl: Int128::zero(),
-                    weight_balance_ratio: Decimal::zero(),
-                    borrow_interest_rate: Decimal::zero(),
-                    funding_rate: Decimal::zero(),
-                    price_impact: Decimal::zero(),
+                    estimated_pnl_denom: "uelys".to_string(),
+                    weight_balance_ratio: Decimal::zero().to_string(),
+                    borrow_interest_rate: Decimal::zero().to_string(),
+                    funding_rate: Decimal::zero().to_string(),
+                    price_impact: Decimal::zero().to_string(),
                 })?)
             }
             ElysQuery::AssetProfileEntryAll { .. } => {

--- a/bindings-test/src/multitest.rs
+++ b/bindings-test/src/multitest.rs
@@ -20,10 +20,17 @@ use elys_bindings::{
         PerpetualOpenResponse,
     },
     query_resp::{
-        AmmSwapEstimationByDenomResponse, AmmSwapEstimationResponse, AuthAddressesResponse, BalanceBorrowed, Commitments, Entry, OracleAssetInfoResponse, PerpetualGetPositionsForAddressResponse, PerpetualMtpResponse, PerpetualOpenEstimationRawResponse, PerpetualQueryPositionsResponse, QueryAprResponse, QueryGetEntryAllResponse, QueryGetEntryResponse, QueryGetPriceResponse, QueryShowCommitmentsResponse, QueryStakedPositionResponse, QueryUnstakedPositionResponse, QueryVestingInfoResponse, StableStakeParamsData, StableStakeParamsResp
+        AmmSwapEstimationByDenomResponse, AmmSwapEstimationResponse, AuthAddressesResponse,
+        BalanceBorrowed, Commitments, Entry, OracleAssetInfoResponse,
+        PerpetualGetPositionsForAddressResponse, PerpetualMtpResponse,
+        PerpetualOpenEstimationRawResponse, PerpetualQueryPositionsResponse, QueryAprResponse,
+        QueryGetEntryAllResponse, QueryGetEntryResponse, QueryGetPriceResponse,
+        QueryShowCommitmentsResponse, QueryStakedPositionResponse, QueryUnstakedPositionResponse,
+        QueryVestingInfoResponse, StableStakeParamsData, StableStakeParamsResp,
     },
     types::{
-        BalanceAvailable, Mtp, OracleAssetInfo, PageResponse, Price, SwapAmountInRoute, SwapAmountOutRoute
+        BalanceAvailable, Mtp, OracleAssetInfo, PageResponse, Price, SwapAmountInRoute,
+        SwapAmountOutRoute,
     },
     ElysMsg, ElysQuery,
 };
@@ -291,7 +298,7 @@ impl Module for ElysModule {
                     position_size: coin(1, "btc"),
                     swap_fee: Decimal::zero().to_string(),
                     open_price: Decimal::zero().to_string(),
-                    take_profit_price : take_profit_price.to_string(),
+                    take_profit_price: take_profit_price.to_string(),
                     liquidation_price: Decimal::zero().to_string(),
                     estimated_pnl: Int128::zero(),
                     estimated_pnl_denom: "uelys".to_string(),

--- a/bindings/src/querier.rs
+++ b/bindings/src/querier.rs
@@ -1,7 +1,8 @@
 use std::str::FromStr;
 
 use cosmwasm_std::{
-    coin, to_json_vec, Binary, Coin, ContractResult, Decimal, QuerierWrapper, QueryRequest, SignedDecimal, SignedDecimal256, StdError, StdResult, SystemResult
+    coin, to_json_vec, Binary, Coin, ContractResult, Decimal, QuerierWrapper, QueryRequest,
+    SignedDecimal, SignedDecimal256, StdError, StdResult, SystemResult,
 };
 
 use crate::{
@@ -119,7 +120,7 @@ impl<'a> ElysQuerier<'a> {
         let request: QueryRequest<ElysQuery> = QueryRequest::Custom(query);
 
         let raw_resp: PerpetualOpenEstimationRawResponse = self.querier.query(&request)?;
-        
+
         let resp: PerpetualOpenEstimationResponse = PerpetualOpenEstimationResponse {
             position: PerpetualPosition::try_from_i32(raw_resp.position)?,
             leverage: SignedDecimal::from_str(&raw_resp.leverage)
@@ -147,9 +148,13 @@ impl<'a> ElysQuerier<'a> {
             estimated_pnl_denom: raw_resp.estimated_pnl_denom,
             available_liquidity: raw_resp.available_liquidity,
             weight_balance_ratio: SignedDecimal::from_str(&raw_resp.weight_balance_ratio)
-                .map_or(SignedDecimal::zero(), |weight_balance_ratio| weight_balance_ratio),
+                .map_or(SignedDecimal::zero(), |weight_balance_ratio| {
+                    weight_balance_ratio
+                }),
             borrow_interest_rate: SignedDecimal::from_str(&raw_resp.borrow_interest_rate)
-                .map_or(SignedDecimal::zero(), |borrow_interest_rate| borrow_interest_rate),
+                .map_or(SignedDecimal::zero(), |borrow_interest_rate| {
+                    borrow_interest_rate
+                }),
             funding_rate: SignedDecimal::from_str(&raw_resp.funding_rate)
                 .map_or(SignedDecimal::zero(), |funding_rate| funding_rate),
             price_impact: SignedDecimal::from_str(&raw_resp.price_impact)

--- a/bindings/src/query_resp.rs
+++ b/bindings/src/query_resp.rs
@@ -1,10 +1,13 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Coin, Decimal, Int128, SignedDecimal, SignedDecimal256, Uint128};
 
-use crate::{trade_shield::types::PerpetualPosition, types::{
-    BalanceAvailable, Mtp, OracleAssetInfo, PageResponse, PoolAsset, Price, StakedPosition,
-    SwapAmountInRoute, SwapAmountOutRoute, UnstakedPosition, ValidatorDetail, VestingDetail,
-}};
+use crate::{
+    trade_shield::types::PerpetualPosition,
+    types::{
+        BalanceAvailable, Mtp, OracleAssetInfo, PageResponse, PoolAsset, Price, StakedPosition,
+        SwapAmountInRoute, SwapAmountOutRoute, UnstakedPosition, ValidatorDetail, VestingDetail,
+    },
+};
 
 #[cw_serde]
 pub struct OracleAllPriceResponse {

--- a/bindings/src/query_resp.rs
+++ b/bindings/src/query_resp.rs
@@ -1,10 +1,10 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Coin, Decimal, Int128, SignedDecimal, SignedDecimal256, Uint128};
 
-use crate::types::{
+use crate::{trade_shield::types::PerpetualPosition, types::{
     BalanceAvailable, Mtp, OracleAssetInfo, PageResponse, PoolAsset, Price, StakedPosition,
     SwapAmountInRoute, SwapAmountOutRoute, UnstakedPosition, ValidatorDetail, VestingDetail,
-};
+}};
 
 #[cw_serde]
 pub struct OracleAllPriceResponse {
@@ -76,6 +76,7 @@ pub struct PerpetualOpenEstimationRawResponse {
     pub take_profit_price: String,
     pub liquidation_price: String,
     pub estimated_pnl: Int128,
+    pub estimated_pnl_denom: String,
     pub available_liquidity: Coin,
     pub weight_balance_ratio: String,
     pub borrow_interest_rate: String,
@@ -85,7 +86,7 @@ pub struct PerpetualOpenEstimationRawResponse {
 
 #[cw_serde]
 pub struct PerpetualOpenEstimationResponse {
-    pub position: i32,
+    pub position: PerpetualPosition,
     pub leverage: SignedDecimal,
     pub trading_asset: String,
     pub collateral: Coin,
@@ -96,13 +97,14 @@ pub struct PerpetualOpenEstimationResponse {
     pub discount: Decimal,
     pub open_price: Decimal,
     pub take_profit_price: SignedDecimal256,
-    pub liquidation_price: Decimal,
+    pub liquidation_price: SignedDecimal,
     pub estimated_pnl: Int128,
+    pub estimated_pnl_denom: String,
     pub available_liquidity: Coin,
-    pub weight_balance_ratio: Decimal,
-    pub borrow_interest_rate: Decimal,
-    pub funding_rate: Decimal,
-    pub price_impact: Decimal,
+    pub weight_balance_ratio: SignedDecimal,
+    pub borrow_interest_rate: SignedDecimal,
+    pub funding_rate: SignedDecimal,
+    pub price_impact: SignedDecimal,
 }
 
 #[cw_serde]

--- a/contracts/trade-shield-contract/src/tests/create_perpetual_order/reproduce_testnet_issue_create_perpetual_market_open_order.rs
+++ b/contracts/trade-shield-contract/src/tests/create_perpetual_order/reproduce_testnet_issue_create_perpetual_market_open_order.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{to_json_binary, Addr, BankMsg, Empty, Int128, Int64, SignedDe
 use cw_multi_test::{AppResponse, BasicAppBuilder, Module};
 use elys_bindings::{
     msg_resp::PerpetualOpenResponse,
-    query_resp::{Entry, PerpetualOpenEstimationResponse, QueryGetEntryResponse},
+    query_resp::{Entry, PerpetualOpenEstimationRawResponse, QueryGetEntryResponse},
     ElysMsg, ElysQuery,
 };
 
@@ -109,43 +109,44 @@ impl Module for ElysModule {
                 take_profit_price,
                 discount,
             } => {
-                let resp = PerpetualOpenEstimationResponse {
-                    position: position.clone(),
-                    leverage: leverage.clone(),
+                let resp = PerpetualOpenEstimationRawResponse {
+                    position,
+                    leverage: leverage.clone().to_string(),
                     trading_asset: trading_asset.clone(),
                     collateral: collateral.clone(),
                     min_collateral: coin(
                         8333333,
                         "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65",
                     ),
-                    valid_collateral: true,
+                    valid_collateral: Some(true),
                     position_size: collateral.clone(),
-                    swap_fee: Decimal::zero(),
-                    discount: discount.clone(),
+                    swap_fee: Decimal::zero().to_string(),
+                    discount: discount.clone().to_string(),
                     open_price: Decimal::from_atomics(Uint128::new(9_440_848_026_817_446_325), 18)
-                        .unwrap(),
-                    take_profit_price: take_profit_price.clone(),
+                        .unwrap().to_string(),
+                    take_profit_price: take_profit_price.clone().to_string(),
                     liquidation_price: Decimal::from_atomics(
                         Uint128::new(9_240_848_026_817_446_325),
                         18,
                     )
-                    .unwrap(),
+                    .unwrap().to_string(),
                     estimated_pnl: Int128::from_str(
                         // "4_999_999_999_999_999_999_999_999_999_999_999_999_527_957_598_6",
                         "4999999999999999999999999999999999999",
                     )
                     .unwrap(),
+                    estimated_pnl_denom: "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65".to_string(),
                     available_liquidity: coin(
                         7705931608,
                         "ibc/E2D2F6ADCC68AA3384B2F5DFACCA437923D137C14E86FB8A10207CF3BED0C8D4",
                     ),
-                    weight_balance_ratio: Decimal::zero(),
+                    weight_balance_ratio: Decimal::zero().to_string(),
                     borrow_interest_rate: Decimal::from_atomics(Uint128::new(323_793_793_684), 18)
-                        .unwrap(),
+                        .unwrap().to_string(),
                     funding_rate: Decimal::from_atomics(Uint128::new(1_000_000_000_000_000), 18)
-                        .unwrap(),
+                        .unwrap().to_string(),
                     price_impact: Decimal::from_atomics(Uint128::new(6_495_303_442_450), 18)
-                        .unwrap(),
+                        .unwrap().to_string(),
                 };
 
                 return Ok(to_json_binary(&resp)?);

--- a/contracts/trade-shield-contract/src/tests/create_perpetual_order/reproduce_testnet_issue_create_perpetual_market_open_order.rs
+++ b/contracts/trade-shield-contract/src/tests/create_perpetual_order/reproduce_testnet_issue_create_perpetual_market_open_order.rs
@@ -123,30 +123,37 @@ impl Module for ElysModule {
                     swap_fee: Decimal::zero().to_string(),
                     discount: discount.clone().to_string(),
                     open_price: Decimal::from_atomics(Uint128::new(9_440_848_026_817_446_325), 18)
-                        .unwrap().to_string(),
+                        .unwrap()
+                        .to_string(),
                     take_profit_price: take_profit_price.clone().to_string(),
                     liquidation_price: Decimal::from_atomics(
                         Uint128::new(9_240_848_026_817_446_325),
                         18,
                     )
-                    .unwrap().to_string(),
+                    .unwrap()
+                    .to_string(),
                     estimated_pnl: Int128::from_str(
                         // "4_999_999_999_999_999_999_999_999_999_999_999_999_527_957_598_6",
                         "4999999999999999999999999999999999999",
                     )
                     .unwrap(),
-                    estimated_pnl_denom: "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65".to_string(),
+                    estimated_pnl_denom:
+                        "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65"
+                            .to_string(),
                     available_liquidity: coin(
                         7705931608,
                         "ibc/E2D2F6ADCC68AA3384B2F5DFACCA437923D137C14E86FB8A10207CF3BED0C8D4",
                     ),
                     weight_balance_ratio: Decimal::zero().to_string(),
                     borrow_interest_rate: Decimal::from_atomics(Uint128::new(323_793_793_684), 18)
-                        .unwrap().to_string(),
+                        .unwrap()
+                        .to_string(),
                     funding_rate: Decimal::from_atomics(Uint128::new(1_000_000_000_000_000), 18)
-                        .unwrap().to_string(),
+                        .unwrap()
+                        .to_string(),
                     price_impact: Decimal::from_atomics(Uint128::new(6_495_303_442_450), 18)
-                        .unwrap().to_string(),
+                        .unwrap()
+                        .to_string(),
                 };
 
                 return Ok(to_json_binary(&resp)?);


### PR DESCRIPTION
…, filed_type

## Change Made:
- [x] fix test because the mocking wasn't returning the RawResponse and so it created a type conflict in the tests
- [x] Some filed was typed as `Decimal` instead of `SignedDecimal`
- [x] implement the new  `estimated_pnl_denom` field
- [x] https://github.com/elys-network/issues/issues/592


## Query Open Estimation the position is now typed and the new field `estimated_pnl_denom` apear just fine

```
$ elysd q --output json --node "tcp://localhost:26657" wasm contract-state smart "elys1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqau4f4q" '{
        "perpetual_open_estimation": {
            "position": "long",
            "leverage": "5",
            "trading_asset": "ibc/E2D2F6ADCC68AA3384B2F5DFACCA437923D137C14E86FB8A10207CF3BED0C8D4",
            "collateral": {"denom": "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65", "amount": "100000000"},
            "take_profit_price": "30",
            "user_address": "elys1d2gklxd0lspfakn2u2ap9c4cr2pct2tcl9jgaz"
        }
    }' | jq
```

```json
{
  "data": {
    "position": "long",
    "leverage": "5",
    "trading_asset": "ibc/E2D2F6ADCC68AA3384B2F5DFACCA437923D137C14E86FB8A10207CF3BED0C8D4",
    "collateral": {
      "denom": "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65",
      "amount": "100000000"
    },
    "min_collateral": {
      "denom": "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65",
      "amount": "9333333"
    },
    "valid_collateral": true,
    "position_size": {
      "denom": "ibc/E2D2F6ADCC68AA3384B2F5DFACCA437923D137C14E86FB8A10207CF3BED0C8D4",
      "amount": "46681971"
    },
    "swap_fee": "0.0007",
    "discount": "0.3",
    "open_price": "0.093363942",
    "take_profit_price": "30",
    "liquidation_price": "0",
    "estimated_pnl": "30015304",
    "estimated_pnl_denom": "ibc/E2D2F6ADCC68AA3384B2F5DFACCA437923D137C14E86FB8A10207CF3BED0C8D4",
    "available_liquidity": {
      "denom": "ibc/E2D2F6ADCC68AA3384B2F5DFACCA437923D137C14E86FB8A10207CF3BED0C8D4",
      "amount": "6481915925"
    },
    "weight_balance_ratio": "0",
    "borrow_interest_rate": "0.000001029614969728",
    "funding_rate": "0.001",
    "price_impact": "0.000000621224454822"
  }
}
```