### PR TITLE
Validators: Optional ID

### DIFF
--- a/bindings/src/types.rs
+++ b/bindings/src/types.rs
@@ -338,7 +338,7 @@ pub struct UnstakedPosition {
 #[cw_serde]
 pub struct ValidatorDetail {
     // Validator Identity
-    pub id: String,
+    pub id: Option<String>,
     // The validator address.
     pub address: String,
     // The validator name.


### PR DESCRIPTION
`get_validators` query is currently failing w/ the error:
```
Error: Query failed with (6): Error parsing into type elys_bindings::query_resp::QueryDelegatorValidatorsResponse: missing field `id`: query wasm contract failed: unknown request
```

This is an attempt to fix the issue. I cannot reproduce this locally so I'm assuming there are validators without this field.