### PR TITLE
feat: add a limit of order that are executed

### DIFF
--- a/bindings/src/trade_shield/msg/execute_msg.rs
+++ b/bindings/src/trade_shield/msg/execute_msg.rs
@@ -112,5 +112,6 @@ pub enum ExecuteMsg {
         perpetual_enabled: Option<bool>,
         reward_enabled: Option<bool>,
         leverage_enabled: Option<bool>,
+        limit_process_order: Option<u128>,
     },
 }

--- a/bindings/src/trade_shield/msg/execute_msg.rs
+++ b/bindings/src/trade_shield/msg/execute_msg.rs
@@ -112,6 +112,6 @@ pub enum ExecuteMsg {
         perpetual_enabled: Option<bool>,
         reward_enabled: Option<bool>,
         leverage_enabled: Option<bool>,
-        limit_process_order: Option<u128>,
+        limit_process_order: Option<u128>, // set to zero set the limit to None
     },
 }

--- a/bindings/src/trade_shield/msg/mod.rs
+++ b/bindings/src/trade_shield/msg/mod.rs
@@ -21,6 +21,7 @@ pub mod query_resp {
     mod get_perpetual_positions_resp;
     mod get_spot_order_resp;
     mod get_spot_orders_resp;
+    mod number_of_pending_order;
     mod params_resp;
 
     pub use get_all_prices_resp::GetAllPricesResponse;
@@ -31,5 +32,6 @@ pub mod query_resp {
     pub use get_perpetual_positions_resp::GetPerpetualPositionsResp;
     pub use get_spot_order_resp::GetSpotOrderResp;
     pub use get_spot_orders_resp::GetSpotOrdersResp;
+    pub use number_of_pending_order::NumberOfPendingOrderResp;
     pub use params_resp::TradeShieldParamsResponse;
 }

--- a/bindings/src/trade_shield/msg/query_msg.rs
+++ b/bindings/src/trade_shield/msg/query_msg.rs
@@ -59,4 +59,6 @@ pub enum QueryMsg {
     },
     #[returns(TradeShieldParamsResponse)]
     GetParams {},
+    #[returns(NumberOfPendingOrderResp)]
+    NumberOfPendingOrder {},
 }

--- a/bindings/src/trade_shield/msg/query_resp/number_of_pending_order.rs
+++ b/bindings/src/trade_shield/msg/query_resp/number_of_pending_order.rs
@@ -1,0 +1,7 @@
+use cosmwasm_schema::cw_serde;
+
+#[cw_serde]
+pub struct NumberOfPendingOrderResp {
+    pub spot_orders: u128,
+    pub perpetual_orders: u128,
+}

--- a/bindings/src/trade_shield/msg/query_resp/params_resp.rs
+++ b/bindings/src/trade_shield/msg/query_resp/params_resp.rs
@@ -10,4 +10,5 @@ pub struct TradeShieldParamsResponse {
     pub perpetual_enabled: bool,
     pub reward_enabled: bool,
     pub leverage_enabled: bool,
+    pub limit_process_order: Option<u128>,
 }

--- a/bindings/src/trade_shield/states/limit_order.rs
+++ b/bindings/src/trade_shield/states/limit_order.rs
@@ -1,0 +1,3 @@
+use cw_storage_plus::Item;
+
+pub const LIMIT_PROCESS_ORDER: Item<Option<u128>> = Item::new("limit order processed");

--- a/bindings/src/trade_shield/states/mod.rs
+++ b/bindings/src/trade_shield/states/mod.rs
@@ -1,10 +1,12 @@
 mod account_history_address;
+mod limit_order;
 mod params;
 mod perpetual_order;
 mod reply_info;
 mod spot_order;
 
 pub use account_history_address::ACCOUNT_HISTORY_ADDRESS;
+pub use limit_order::LIMIT_PROCESS_ORDER;
 pub use params::{
     LEVERAGE_ENABLED, MARKET_ORDER_ENABLED, PARAMS_ADMIN, PERPETUAL_ENABLED,
     PROCESS_ORDERS_ENABLED, REWARD_ENABLED, STAKE_ENABLED, SWAP_ENABLED,

--- a/contracts/trade-shield-contract/src/entry_point/execute.rs
+++ b/contracts/trade-shield-contract/src/entry_point/execute.rs
@@ -3,7 +3,7 @@ use crate::helper::get_discount;
 use super::*;
 use cosmwasm_std::{Int128, StdError, SubMsg};
 use elys_bindings::trade_shield::states::{
-    LEVERAGE_ENABLED, MARKET_ORDER_ENABLED, PARAMS_ADMIN, PERPETUAL_ENABLED,
+    LEVERAGE_ENABLED, LIMIT_PROCESS_ORDER, MARKET_ORDER_ENABLED, PARAMS_ADMIN, PERPETUAL_ENABLED,
     PROCESS_ORDERS_ENABLED, REWARD_ENABLED, STAKE_ENABLED, SWAP_ENABLED,
 };
 use msg::ExecuteMsg;
@@ -172,6 +172,7 @@ pub fn execute(
             perpetual_enabled,
             reward_enabled,
             leverage_enabled,
+            limit_process_order,
         } => {
             let admin = PARAMS_ADMIN.load(deps.storage)?;
 
@@ -198,6 +199,12 @@ pub fn execute(
             }
             if let Some(leverage_enabled) = leverage_enabled {
                 LEVERAGE_ENABLED.save(deps.storage, &leverage_enabled)?;
+            }
+            if let Some(limit_process_order) = limit_process_order {
+                match limit_process_order {
+                    0 => LIMIT_PROCESS_ORDER.save(deps.storage, &None)?,
+                    x => LIMIT_PROCESS_ORDER.save(deps.storage, &Some(x))?,
+                };
             }
             Ok(Response::new())
         }

--- a/contracts/trade-shield-contract/src/entry_point/instantiate.rs
+++ b/contracts/trade-shield-contract/src/entry_point/instantiate.rs
@@ -24,5 +24,6 @@ pub fn instantiate(
     PERPETUAL_ENABLED.save(deps.storage, &state)?;
     REWARD_ENABLED.save(deps.storage, &state)?;
     LEVERAGE_ENABLED.save(deps.storage, &state)?;
+    LIMIT_PROCESS_ORDER.save(deps.storage, &None)?;
     Ok(Response::new())
 }

--- a/contracts/trade-shield-contract/src/entry_point/migrate.rs
+++ b/contracts/trade-shield-contract/src/entry_point/migrate.rs
@@ -1,8 +1,9 @@
 use elys_bindings::trade_shield::{
     msg::MigrateMsg,
     states::{
-        ACCOUNT_HISTORY_ADDRESS, LEVERAGE_ENABLED, MARKET_ORDER_ENABLED, PARAMS_ADMIN,
-        PERPETUAL_ENABLED, PROCESS_ORDERS_ENABLED, REWARD_ENABLED, STAKE_ENABLED, SWAP_ENABLED,
+        ACCOUNT_HISTORY_ADDRESS, LEVERAGE_ENABLED, LIMIT_PROCESS_ORDER, MARKET_ORDER_ENABLED,
+        PARAMS_ADMIN, PERPETUAL_ENABLED, PROCESS_ORDERS_ENABLED, REWARD_ENABLED, STAKE_ENABLED,
+        SWAP_ENABLED,
     },
 };
 
@@ -29,6 +30,7 @@ pub fn migrate(
     PERPETUAL_ENABLED.save(deps.storage, &state)?;
     REWARD_ENABLED.save(deps.storage, &state)?;
     LEVERAGE_ENABLED.save(deps.storage, &state)?;
+    LIMIT_PROCESS_ORDER.save(deps.storage, &None)?;
 
     Ok(Response::new())
 }

--- a/contracts/trade-shield-contract/src/entry_point/query.rs
+++ b/contracts/trade-shield-contract/src/entry_point/query.rs
@@ -1,10 +1,13 @@
 use super::*;
+use cosmwasm_std::Order;
 use elys_bindings::trade_shield::{
-    msg::query_resp::TradeShieldParamsResponse,
+    msg::query_resp::{NumberOfPendingOrderResp, TradeShieldParamsResponse},
     states::{
-        LEVERAGE_ENABLED, MARKET_ORDER_ENABLED, PARAMS_ADMIN, PERPETUAL_ENABLED,
-        PROCESS_ORDERS_ENABLED, REWARD_ENABLED, STAKE_ENABLED, SWAP_ENABLED,
+        LEVERAGE_ENABLED, LIMIT_PROCESS_ORDER, MARKET_ORDER_ENABLED, PARAMS_ADMIN,
+        PENDING_PERPETUAL_ORDER, PENDING_SPOT_ORDER, PERPETUAL_ENABLED, PROCESS_ORDERS_ENABLED,
+        REWARD_ENABLED, STAKE_ENABLED, SWAP_ENABLED,
     },
+    types::{PerpetualOrder, SpotOrder},
 };
 use msg::QueryMsg;
 
@@ -82,6 +85,21 @@ pub fn query(deps: Deps<ElysQuery>, _env: Env, msg: QueryMsg) -> Result<Binary, 
         } => Ok(to_json_binary(&query::perpetual_get_position_for_address(
             deps, address, pagination,
         )?)?),
+        NumberOfPendingOrder {} => {
+            let spot_orders: Vec<SpotOrder> = PENDING_SPOT_ORDER
+                .prefix_range(deps.storage, None, None, Order::Ascending)
+                .filter_map(|res| res.ok().map(|r| r.1))
+                .collect();
+            let perpetual_orders: Vec<PerpetualOrder> = PENDING_PERPETUAL_ORDER
+                .prefix_range(deps.storage, None, None, Order::Ascending)
+                .filter_map(|res| res.ok().map(|r| r.1))
+                .collect();
+
+            Ok(to_json_binary(&NumberOfPendingOrderResp {
+                spot_orders: spot_orders.len() as u128,
+                perpetual_orders: perpetual_orders.len() as u128,
+            })?)
+        }
         GetParams {} => Ok(to_json_binary(&{
             let params_admin = PARAMS_ADMIN.load(deps.storage)?;
 
@@ -92,6 +110,7 @@ pub fn query(deps: Deps<ElysQuery>, _env: Env, msg: QueryMsg) -> Result<Binary, 
             let perpetual_enabled = PERPETUAL_ENABLED.load(deps.storage)?;
             let reward_enabled = REWARD_ENABLED.load(deps.storage)?;
             let leverage_enabled = LEVERAGE_ENABLED.load(deps.storage)?;
+            let limit_process_order = LIMIT_PROCESS_ORDER.load(deps.storage)?;
 
             TradeShieldParamsResponse {
                 params_admin,
@@ -102,6 +121,7 @@ pub fn query(deps: Deps<ElysQuery>, _env: Env, msg: QueryMsg) -> Result<Binary, 
                 perpetual_enabled,
                 reward_enabled,
                 leverage_enabled,
+                limit_process_order,
             }
         })?),
     }

--- a/contracts/trade-shield-contract/src/tests/mock/instantiate.rs
+++ b/contracts/trade-shield-contract/src/tests/mock/instantiate.rs
@@ -76,5 +76,7 @@ pub fn instantiate(
     PERPETUAL_ENABLED.save(deps.storage, &state)?;
     REWARD_ENABLED.save(deps.storage, &state)?;
     LEVERAGE_ENABLED.save(deps.storage, &state)?;
+    LIMIT_PROCESS_ORDER.save(deps.storage, &None)?;
+
     Ok(Response::new())
 }

--- a/scripts/messages.sh
+++ b/scripts/messages.sh
@@ -359,6 +359,20 @@ function disable_all_params() {
     wasm-cancel_perpetual_order
 }
 
+function set_limit_to_process_orders() {
+    #set limit to process orders: set to zero for the limit to be NONE
+    limit_number=$1
+    printf "\n# Set Params\n"
+    execute_message \
+    "$ts_contract_address" \
+    '{
+        "set_params": {
+            "limit_process_order": '"$limit_number"'
+        }
+    }'\
+    wasm-cancel_perpetual_order
+}
+
 # function(s) to run based on the provided argument
 case "$1" in
     "amm_swap_exact_amount_in")
@@ -412,7 +426,9 @@ case "$1" in
     "disable_all_params")
         disable_all_params
         ;;
-
+    "set_limit_to_process_orders")
+        set_limit_to_process_orders $2
+        ;;
     *)
         # Default case: run all functions
         all_spot_orders

--- a/scripts/queries.sh
+++ b/scripts/queries.sh
@@ -460,6 +460,15 @@ function ts_params() {
         "get_params": {}
     }'
 }
+
+function number_of_pending_orders() {
+    printf "\n# number_of_pending_orders\n"
+    query_contract \
+    "$ts_contract_address" \
+    '{
+        "number_of_pending_order": {}
+    }'
+}
 # function(s) to run based on the provided argument
 case "$2" in
     "ah_params")
@@ -606,7 +615,9 @@ case "$2" in
     "ts_params")
         ts_params
         ;;
-
+    "number_of_pending_orders")
+        number_of_pending_orders
+        ;;
     *)
         # Default case: run all functions
         ah_params


### PR DESCRIPTION
## Add a field to `SetParams` and `GetParams` response:

### `GetParams` response:
```rust
pub struct TradeShieldParamsResponse {
    pub params_admin: String,
    pub market_order_enabled: bool,
    pub stake_enabled: bool,
    pub process_order_enabled: bool,
    pub swap_enabled: bool,
    pub perpetual_enabled: bool,
    pub reward_enabled: bool,
    pub leverage_enabled: bool,
    pub limit_process_order: Option<u128>,
}
```
### `SetParams`:
```rust
    SetParams {
        market_order_enabled: Option<bool>,
        stake_enabled: Option<bool>,
        process_order_enabled: Option<bool>,
        swap_enabled: Option<bool>,
        perpetual_enabled: Option<bool>,
        reward_enabled: Option<bool>,
        leverage_enabled: Option<bool>,
        limit_process_order: Option<u128>, // set to zero set the limit to None
    },
```

## `NumberOfPendingOrder`:
### Query
```rust
    NumberOfPendingOrder {},
```
### Response
```rust
pub struct NumberOfPendingOrderResp {
    pub spot_orders: u128,
    pub perpetual_orders: u128,
}
```
###