### PR TITLE
Adds new exit pool estimation query

### DIFF
--- a/bindings-test/src/multitest.rs
+++ b/bindings-test/src/multitest.rs
@@ -159,6 +159,7 @@ impl Module for ElysModule {
             ElysQuery::AmmEarnMiningPoolAll { .. } => todo!("AmmEarnMiningPoolAll"),
             ElysQuery::IncentivePoolAprs { .. } => todo!("IncentivePoolAprs"),
             ElysQuery::AmmJoinPoolEstimation { .. } => todo!("AmmJoinPoolEstimation"),
+            ElysQuery::AmmExitPoolEstimation { .. } => todo!("AmmJoinPoolEstimation"),
             ElysQuery::CommitmentAllValidators { .. } => todo!("CommitmentAllValidators"),
             ElysQuery::CommitmentDelegations { .. } => todo!("CommitmentDelegations"),
             ElysQuery::CommitmentDelegatorValidators { .. } => {

--- a/bindings/src/account_history/msg/query.rs
+++ b/bindings/src/account_history/msg/query.rs
@@ -5,7 +5,7 @@ use super::query_resp::*;
 #[allow(unused_imports)]
 use crate::query_resp::{
     AuthAddressesResponse, BalanceBorrowed, PoolFilterType, QueryEarnPoolResponse,
-    QueryIncentivePoolAprsResponse, QueryJoinPoolEstimationResponse,
+    QueryIncentivePoolAprsResponse, QueryJoinPoolEstimationResponse, QueryExitPoolEstimationResponse,
     QueryStakedPositionResponse, QueryUnstakedPositionResponse, QueryUserPoolResponse,
     QueryVestingInfoResponse, StableStakeParamsData, StakedAvailable, QueryPoolAssetEstimationResponse
 };
@@ -57,6 +57,12 @@ pub enum QueryMsg {
     JoinPoolEstimation {
         pool_id: u64,
         amounts_in: Vec<Coin> 
+    },
+    
+    #[returns(QueryExitPoolEstimationResponse)]
+    ExitPoolEstimation {
+        pool_id: u64,
+        exit_fiat_amount: Decimal
     },
 
     #[returns(QueryPoolAssetEstimationResponse)]

--- a/bindings/src/querier.rs
+++ b/bindings/src/querier.rs
@@ -2,8 +2,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use cosmwasm_std::{
-    coin, to_json_vec, Binary, Coin, ContractResult, Decimal, QuerierWrapper, QueryRequest,
-    SignedDecimal, SignedDecimal256, StdError, StdResult, SystemResult,
+    coin, to_json_vec, Binary, Coin, ContractResult, Decimal, QuerierWrapper, QueryRequest, SignedDecimal, SignedDecimal256, StdError, StdResult, SystemResult, Uint128
 };
 
 use crate::{
@@ -551,6 +550,17 @@ impl<'a> ElysQuerier<'a> {
         let query = ElysQuery::join_pool_estimation(pool_id, amounts_in);
         let request: QueryRequest<ElysQuery> = QueryRequest::Custom(query);
         let response: QueryJoinPoolEstimationResponse = self.querier.query(&request)?;
+        Ok(response)
+    }
+
+    pub fn exit_pool_estimation(
+        &self,
+        pool_id: u64,
+        share_amount_in: Uint128
+    ) -> StdResult<QueryExitPoolEstimationResponse> {
+        let query = ElysQuery::exit_pool_estimation(pool_id, share_amount_in, "".to_string());
+        let request: QueryRequest<ElysQuery> = QueryRequest::Custom(query);
+        let response: QueryExitPoolEstimationResponse = self.querier.query(&request)?;
         Ok(response)
     }
 

--- a/bindings/src/query.rs
+++ b/bindings/src/query.rs
@@ -6,7 +6,7 @@ use crate::types::{BalanceAvailable, PageRequest, SwapAmountInRoute};
 use super::query_resp::*;
 
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Coin, CustomQuery, Decimal, SignedDecimal, SignedDecimal256};
+use cosmwasm_std::{Coin, CustomQuery, Decimal, SignedDecimal, SignedDecimal256, Uint128};
 
 // Now define ElysQuery to include the new OracleQuery and AmmQuery
 #[cw_serde]
@@ -115,6 +115,8 @@ pub enum ElysQuery {
     IncentivePoolAprs { pool_ids: Option<Vec<u64>> },
     #[returns(QueryJoinPoolEstimationResponse)]
     AmmJoinPoolEstimation { pool_id: u64, amounts_in: Vec<Coin> },
+    #[returns(QueryExitPoolEstimationResponse)]
+    AmmExitPoolEstimation{ pool_id: u64, share_amount_in: Uint128, token_out_denom: String },
     #[returns(LeveragelpParamsResponse)]
     LeveragelpParams {},
     #[returns(LeveragelpPositionsResponse)]
@@ -327,6 +329,13 @@ impl ElysQuery {
         ElysQuery::AmmJoinPoolEstimation {
             pool_id,
             amounts_in,
+        }
+    }
+    pub fn exit_pool_estimation(pool_id: u64, share_amount_in: Uint128, token_out_denom: String) -> Self {
+        ElysQuery::AmmExitPoolEstimation {
+            pool_id,
+            share_amount_in,
+            token_out_denom
         }
     }
 }

--- a/bindings/src/query_resp.rs
+++ b/bindings/src/query_resp.rs
@@ -439,6 +439,11 @@ pub struct QueryPoolAssetEstimationResponse {
 }
 
 #[cw_serde]
+pub struct QueryExitPoolEstimationResponse {
+    pub amounts_out: Vec<Coin>
+}
+
+#[cw_serde]
 pub struct QueryUserPoolResponse {
     // Total Rewards in fiat
     pub rewards: Decimal,

--- a/contracts/account-history-contract/src/action/mod.rs
+++ b/contracts/account-history-contract/src/action/mod.rs
@@ -13,6 +13,7 @@ pub mod query {
     mod get_pools_apr;
     mod join_pool_estimation;
     mod pool_asset_estimation;
+    mod exit_pool_estimation;
     mod get_portfolio;
     mod get_rewards;
     mod get_total_balance;
@@ -44,6 +45,7 @@ pub mod query {
     pub use get_pools_apr::get_pools_apr;
     pub use join_pool_estimation::join_pool_estimation;
     pub use pool_asset_estimation::pool_asset_estimation;
+    pub use exit_pool_estimation::exit_pool_estimation;
     mod get_eden_boost_earn_program_details;
     pub use get_eden_boost_earn_program_details::get_eden_boost_earn_program_details;
     pub use get_liquid_assets::get_liquid_assets;

--- a/contracts/account-history-contract/src/action/query/exit_pool_estimation.rs
+++ b/contracts/account-history-contract/src/action/query/exit_pool_estimation.rs
@@ -1,0 +1,40 @@
+use cosmwasm_std::{Decimal, Deps, StdError, StdResult, Uint128};
+use elys_bindings::{ElysQuerier, ElysQuery};
+use elys_bindings::query_resp::{PoolFilterType, QueryExitPoolEstimationResponse};
+
+/**
+ * Given a pool id and a fiat amount, determine the assets the user will
+ * get in return.
+ */
+pub fn exit_pool_estimation(
+    deps: Deps<ElysQuery>,
+    pool_id: u64,
+    exit_fiat_amount: Decimal
+) -> StdResult<QueryExitPoolEstimationResponse> {
+    let querier = ElysQuerier::new(&deps.querier);
+
+    let pool_response = querier.get_all_pools(Some(vec![pool_id]), PoolFilterType::FilterAll as i32, None)?;
+    let pool = match pool_response.pools {
+        Some(pools) => {
+            if let Some(pool) = pools.first() {
+                pool.clone()
+            } else {
+                return Err(StdError::generic_err("Pool not found"));
+            }
+        }
+        None => return Err(StdError::generic_err("Failed to fetch pool")),
+    };
+
+    let share_price = match pool.share_usd_price {
+        Some(share) => share,
+        None => return Err(StdError::generic_err("Unable to get share price"))
+    };
+    let share_amount = exit_fiat_amount
+        .checked_div(share_price)
+        .unwrap_or_default();
+
+    match querier.exit_pool_estimation(pool_id, Uint128::new(share_amount.atomics().into())) {
+        Ok(response) => Ok(response),
+        Err(err) => return Err(StdError::generic_err(format!("exit_pool_estimation: Error getting estimation from chain:{:?}", err)))
+    }
+}

--- a/contracts/account-history-contract/src/entry_point/query.rs
+++ b/contracts/account-history-contract/src/entry_point/query.rs
@@ -6,7 +6,7 @@ use crate::action::query::{
 #[cfg(feature = "debug")]
 use crate::action::query::{
     all, get_pools, get_pools_apr, join_pool_estimation, last_snapshot, params, user_snapshots, user_value,
-    pool_asset_estimation
+    pool_asset_estimation, exit_pool_estimation
 };
 
 use cosmwasm_std::{entry_point, to_json_binary, Binary, Deps, Env, StdResult};
@@ -71,6 +71,11 @@ pub fn query(deps: Deps<ElysQuery>, env: Env, msg: QueryMsg) -> StdResult<Binary
             pool_id,
             amount
         } => to_json_binary(&pool_asset_estimation(deps, pool_id, amount)?),
+
+        ExitPoolEstimation {
+            pool_id,
+            exit_fiat_amount
+        } => to_json_binary(&exit_pool_estimation(deps, pool_id, exit_fiat_amount)?),
 
         GetAssetPriceFromDenomInToDenomOut {
             denom_in,


### PR DESCRIPTION
To be used by the FE as part of [this ticket](https://trello.com/c/XjSGy3Wm/197-page-earn-liquidity-mining-withdraw).

Given a pool id and a fiat amount in US Dollars, you get how much assets you would get based on your pool participation and current pool ratio..
![Screenshot 2024-04-17 at 5 59 17 PM](https://github.com/elys-network/bindings/assets/12855914/117c7a09-e56e-4731-9c5e-5ee236ef342b)

Response:
```
{
  "amounts_out": [
    {
      "denom": "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65",
      "amount": "561438"
    },
    {
      "denom": "ibc/E2D2F6ADCC68AA3384B2F5DFACCA437923D137C14E86FB8A10207CF3BED0C8D4",
      "amount": "85334"
    }
  ]
}
```