### PR TITLE
Add Estaking Rewards 

### DIFF
--- a/bindings-test/src/multitest.rs
+++ b/bindings-test/src/multitest.rs
@@ -121,6 +121,7 @@ impl Module for ElysModule {
                 Ok(to_json_binary(&resp)?)
             }
 
+            ElysQuery::EstakingRewards { .. } => todo!("QueryEstakingRewards"),
             ElysQuery::LeveragelpQueryPositions { .. } => todo!("LeveragelpQueryPositions"),
             ElysQuery::LeveragelpQueryPositionsByPool { .. } => {
                 todo!("LeveragelpQueryPositionsByPool")

--- a/bindings/src/account_history/msg/mod.rs
+++ b/bindings/src/account_history/msg/mod.rs
@@ -43,4 +43,9 @@ pub mod query_resp {
         mod get_usdc_earn_details_resp;
         pub use get_usdc_earn_details_resp::GetUsdcEarnProgramResp;
     }
+
+    pub mod estaking {
+        mod get_estaking_rewards_response;
+        pub use get_estaking_rewards_response::GetEstakingRewardsResponse;
+    }
 }

--- a/bindings/src/account_history/msg/query.rs
+++ b/bindings/src/account_history/msg/query.rs
@@ -7,13 +7,15 @@ use crate::query_resp::{
     AuthAddressesResponse, BalanceBorrowed, PoolFilterType, QueryEarnPoolResponse,
     QueryIncentivePoolAprsResponse, QueryJoinPoolEstimationResponse, QueryExitPoolEstimationResponse,
     QueryStakedPositionResponse, QueryUnstakedPositionResponse, QueryUserPoolResponse,
-    QueryVestingInfoResponse, StableStakeParamsData, StakedAvailable, QueryPoolAssetEstimationResponse
+    QueryVestingInfoResponse, StableStakeParamsData, StakedAvailable, QueryPoolAssetEstimationResponse,
+    EstakingRewardsResponse
 };
 #[allow(unused_imports)]
 use crate::types::{BalanceAvailable, PageRequest};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 #[cfg(feature = "debug")]
 use cosmwasm_std::{Coin, DecCoin, Decimal};
+use super::query_resp::estaking::*;
 
 #[cw_serde]
 #[derive(QueryResponses)]
@@ -70,6 +72,9 @@ pub enum QueryMsg {
         pool_id: u64,
         amount: DecCoin
     },
+    
+    #[returns(GetEstakingRewardsResponse)]
+    GetEstakingRewards {address: String},
 
     // debug only
     #[cfg(feature = "debug")]
@@ -130,5 +135,5 @@ pub enum QueryMsg {
 
     #[cfg(feature = "debug")]
     #[returns(Decimal)]
-    AmmPriceByDenom { token_in: Coin, discount: Decimal },
+    AmmPriceByDenom { token_in: Coin, discount: Decimal }
 }

--- a/bindings/src/account_history/msg/query_resp/estaking/get_estaking_rewards_response.rs
+++ b/bindings/src/account_history/msg/query_resp/estaking/get_estaking_rewards_response.rs
@@ -1,0 +1,16 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::DecCoin;
+
+use crate::account_history::types::DecCoinValue;
+
+#[cw_serde]
+pub struct GetEstakingRewardsResponse {
+    pub rewards: Vec<(String, DecCoinValue)>,
+    pub total: Vec<DecCoin>
+}
+
+#[cw_serde]
+pub struct DelegationDelegatorReward {
+    pub validator_address: String,
+    pub reward: Vec<DecCoinValue>
+}

--- a/bindings/src/account_history/types/coin_value.rs
+++ b/bindings/src/account_history/types/coin_value.rs
@@ -1,6 +1,6 @@
 use crate::{query_resp::OracleAssetInfoResponse, types::OracleAssetInfo, ElysQuerier};
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Coin, Decimal, StdError, StdResult};
+use cosmwasm_std::{Coin, DecCoin, Decimal, Decimal256, StdError, StdResult};
 
 #[cw_serde]
 pub struct CoinValue {
@@ -8,6 +8,14 @@ pub struct CoinValue {
     pub amount_token: Decimal,
     pub price: Decimal,
     pub amount_usd: Decimal,
+}
+
+#[cw_serde]
+pub struct DecCoinValue {
+    pub denom: String,
+    pub amount_token: Decimal256,
+    pub price: Decimal,
+    pub amount_usd: Decimal256
 }
 
 impl CoinValue {
@@ -19,6 +27,7 @@ impl CoinValue {
             amount_usd,
         }
     }
+
     pub fn from_coin(
         balance: &Coin,
         querier: &ElysQuerier<'_>,
@@ -90,5 +99,58 @@ impl CoinValue {
             price,
             amount_usd,
         })
+    }
+}
+
+impl DecCoinValue {
+    pub fn from_dec_coin(
+        balance: &DecCoin,
+        querier: &ElysQuerier<'_>,
+        usdc_denom: &String,
+    ) -> StdResult<Self> {
+        if &balance.denom == usdc_denom {
+            let price = querier.get_asset_price(usdc_denom)?;
+            let amount_usd = balance.amount.checked_mul(Decimal256::from(price.clone())).map_err(|e| {
+                StdError::generic_err(format!("failed to convert amount to amount_usd: {}", e))
+            })?;
+
+            return Ok(Self {
+                denom: balance.denom.clone(),
+                amount_usd,
+                price,
+                amount_token: balance.amount,
+            });
+        }
+
+        let price = querier
+            .get_asset_price(balance.denom.clone())
+            .map_err(|e| StdError::generic_err(format!("failed to get_asset_price: {}", e)))?;
+
+        let amount_usd = balance.amount
+            .checked_mul(Decimal256::from(price.clone()))
+            .map_err(|e| {
+                StdError::generic_err(format!(
+                    "failed to convert amount_usd_base to Decimal: {}",
+                    e
+                ))
+            })?;
+
+        Ok(Self {
+            denom: balance.denom.clone(),
+            amount_token: balance.amount.clone(),
+            price,
+            amount_usd,
+        })
+    }
+}
+
+impl Default for DecCoinValue {
+    fn default() -> Self {
+        Self {
+            amount_token: Decimal256::zero(),
+            amount_usd: Decimal256::zero(),
+            denom: "".to_string(),
+            price: Decimal::zero()
+        }
     }
 }

--- a/bindings/src/account_history/types/mod.rs
+++ b/bindings/src/account_history/types/mod.rs
@@ -12,6 +12,7 @@ mod total_balance;
 
 pub use account_snapshot::AccountSnapshot;
 pub use coin_value::CoinValue;
+pub use coin_value::DecCoinValue;
 pub use metadata::Metadata;
 pub use portfolio_balance_snapshot::PortfolioBalanceSnapshot;
 

--- a/bindings/src/querier.rs
+++ b/bindings/src/querier.rs
@@ -799,6 +799,17 @@ impl<'a> ElysQuerier<'a> {
             ))
         })
     }
+
+    pub fn get_estaking_rewards(
+        &self,
+        address: String,
+    ) -> StdResult<EstakingRewardsResponse> {
+        let query = ElysQuery::EstakingRewards { address: address.to_owned() };
+        let request: QueryRequest<ElysQuery> = QueryRequest::Custom(query);
+        let resp: EstakingRewardsResponse = self.querier.query(&request)?;
+        Ok(resp)
+    }
+
     #[allow(dead_code)]
     #[cfg(feature = "debug")]
     fn query_binary(&self, request: &QueryRequest<ElysQuery>) -> StdResult<Binary> {

--- a/bindings/src/query.rs
+++ b/bindings/src/query.rs
@@ -143,6 +143,10 @@ pub enum ElysQuery {
     LeveragelpPools { pagination: Option<PageRequest> },
     #[returns(LeveragelpPositionResponse)]
     LeveragelpPosition { address: String, id: u64 },
+    #[returns(EstakingRewardsResponse)]
+    EstakingRewards {
+        address: String
+    }
 }
 
 impl CustomQuery for ElysQuery {}
@@ -336,6 +340,11 @@ impl ElysQuery {
             pool_id,
             share_amount_in,
             token_out_denom
+        }
+    }
+    pub fn query_estaking_rewards(address: String) -> Self {
+        ElysQuery::EstakingRewards {
+            address
         }
     }
 }

--- a/bindings/src/query_resp.rs
+++ b/bindings/src/query_resp.rs
@@ -1,17 +1,17 @@
 use std::collections::HashMap;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Coin, Decimal, Decimal256, Int128, SignedDecimal, SignedDecimal256, Uint128};
+use cosmwasm_std::{Coin, DecCoin, Decimal, Decimal256, Int128, SignedDecimal, SignedDecimal256, StdResult, Uint128};
 
 use crate::{
-    account_history::types::CoinValue,
+    account_history::types::{CoinValue, DecCoinValue},
     trade_shield::types::{
         AmmPool, AmmPoolRaw, PerpetualPosition, PoolExtraInfo, StakedPositionRaw,
     },
     types::{
         BalanceAvailable, Mtp, OracleAssetInfo, PageResponse, PoolAsset, Price, StakedPosition,
         SwapAmountInRoute, SwapAmountOutRoute, UnstakedPosition, ValidatorDetail, VestingDetail,
-    }
+    }, ElysQuerier
 };
 
 #[cw_serde]
@@ -609,4 +609,41 @@ pub struct LeveragelpPoolResponse {
 pub struct LeveragelpPoolsResponse {
     pub pool: Vec<LeveragelpPool>,
     pub pagination: Option<PageResponse>,
+}
+
+#[cw_serde]
+pub struct EstakingRewardsResponse {
+    pub rewards: Vec<DelegationDelegatorReward>,
+    pub total: Vec<DecCoin>
+}
+
+#[cw_serde]
+pub struct DelegationDelegatorReward {
+    pub validator_address: String,
+    pub reward: Vec<DecCoin>
+}
+
+impl Default for EstakingRewardsResponse {
+    fn default() -> Self {
+        Self {
+            rewards: [].to_vec(),
+            total: [].to_vec()
+        }
+    }
+}
+
+impl EstakingRewardsResponse {
+    pub fn to_dec_coin_values(&self, querier: &ElysQuerier<'_>, usdc_denom: &String) -> StdResult<Vec<(String, DecCoinValue)>> {
+        let mut dec_coin_values = Vec::new();
+
+        for delegation_reward in &self.rewards {
+            let validator_address = delegation_reward.validator_address.clone();
+            for dec_coin in &delegation_reward.reward {
+                let dec_coin_value = DecCoinValue::from_dec_coin(dec_coin, querier, usdc_denom)?;
+                dec_coin_values.push((validator_address.clone(), dec_coin_value));
+            }
+        }
+
+        Ok(dec_coin_values)
+    }
 }

--- a/contracts/account-history-contract/src/action/mod.rs
+++ b/contracts/account-history-contract/src/action/mod.rs
@@ -17,6 +17,7 @@ pub mod query {
     mod get_portfolio;
     mod get_rewards;
     mod get_total_balance;
+    mod get_estaking_rewards;
 
     #[cfg(feature = "debug")]
     mod all;
@@ -62,4 +63,5 @@ pub mod query {
     pub use get_rewards::get_rewards;
     pub use get_staked_assets::get_staked_assets;
     pub use get_total_balance::get_total_balance;
+    pub use get_estaking_rewards::get_estaking_rewards;
 }

--- a/contracts/account-history-contract/src/action/query/get_estaking_rewards.rs
+++ b/contracts/account-history-contract/src/action/query/get_estaking_rewards.rs
@@ -1,0 +1,28 @@
+use cosmwasm_std::{Deps, StdResult};
+use elys_bindings::account_history::msg::query_resp::estaking::GetEstakingRewardsResponse;
+use elys_bindings::{ElysQuerier, ElysQuery};
+
+use crate::types::AccountSnapshotGenerator;
+
+/**
+ * Given a user address, gets the Estaking rewards available.
+ */
+pub fn get_estaking_rewards(
+    deps: Deps<ElysQuery>,
+    address: String
+) -> StdResult<GetEstakingRewardsResponse> {
+    let querier = ElysQuerier::new(&deps.querier);
+
+    let generator = AccountSnapshotGenerator::new(&deps)?;
+
+    let response = querier.get_estaking_rewards(address).unwrap_or_default();
+
+    let fiat_coins = response
+        .to_dec_coin_values(&querier, &generator.metadata.usdc_denom)
+        .unwrap_or_default();
+
+    Ok(GetEstakingRewardsResponse {
+        rewards: fiat_coins,
+        total: response.total
+    })
+}

--- a/contracts/account-history-contract/src/entry_point/query.rs
+++ b/contracts/account-history-contract/src/entry_point/query.rs
@@ -1,6 +1,5 @@
 use crate::action::query::{
-    get_liquid_assets, get_membership_tier, get_perpetuals_assets, get_pool_balances,
-    get_portfolio, get_rewards, get_staked_assets, get_total_balance,
+    get_estaking_rewards, get_liquid_assets, get_membership_tier, get_perpetuals_assets, get_pool_balances, get_portfolio, get_rewards, get_staked_assets, get_total_balance
 };
 
 #[cfg(feature = "debug")]
@@ -86,6 +85,10 @@ pub fn query(deps: Deps<ElysQuery>, env: Env, msg: QueryMsg) -> StdResult<Binary
                 &querier.get_asset_price_from_denom_in_to_denom_out(denom_in, denom_out)?,
             )
         }
+
+        GetEstakingRewards {
+            address
+        } => to_json_binary(&get_estaking_rewards(deps, address)?),
 
         // debug only
         #[cfg(feature = "debug")]


### PR DESCRIPTION
I still need to test this using Upgrade assure since it's the response is not being correctly mapped very likely because `DecCoin` is not able to convert to USD.

The message to the chain is working though.
```
elysd q --output json wasm contract-state smart elys17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgs98tvuy '{"get_estaking_rewards": {"address": "elys12tzylat4udvjj56uuhu3vj2n4vgp7cf9fwna9w"}}' | jq
{
  "data": {
    "rewards": [
      {
        "validator_address": "elysvaloper12tzylat4udvjj56uuhu3vj2n4vgp7cf9pwcqcs",
        "reward": [
          {
            "denom": "ueden",
            "amount": "9744.336"
          },
          {
            "denom": "uedenb",
            "amount": "38977.344"
          },
          {
            "denom": "uelys",
            "amount": "6350400"
          }
        ]
      }
    ],
    "total": [
      {
        "denom": "ueden",
        "amount": "9744.336"
      },
      {
        "denom": "uedenb",
        "amount": "38977.344"
      },
      {
        "denom": "uelys",
        "amount": "6350400"
      }
    ]
  }
}
```