### PR TITLE
Fix Process perpetual 

### DIFF
--- a/contracts/trade-shield-contract/src/action/sudo/process_orders.rs
+++ b/contracts/trade-shield-contract/src/action/sudo/process_orders.rs
@@ -121,8 +121,9 @@ pub fn process_orders(
         let (order_position_type, order_type, base_denom, quote_denom) =
             PerpetualOrder::from_key(key.as_str())?;
 
+        //get the price in usdc
         let market_price =
-            match querier.get_asset_price_from_denom_in_to_denom_out(&base_denom, &quote_denom) {
+            match querier.get_asset_price_from_denom_in_to_denom_out(&quote_denom, &base_denom) {
                 Ok(market_price) => market_price,
                 Err(_) => {
                     cancel_perpetual_orders(deps.storage, key, &order_ids, None)?;

--- a/contracts/trade-shield-contract/src/tests/mod.rs
+++ b/contracts/trade-shield-contract/src/tests/mod.rs
@@ -84,13 +84,13 @@ mod cancel_perpetual_order {
     mod unauthorize;
 }
 
-// mod process_perpetual_order {
-//     use super::*;
-//     mod pending_limit_open_long_with_price_met;
-//     mod pending_limit_open_long_with_price_not_met;
-//     mod pending_limit_open_short_with_price_met;
-//     mod pending_limit_open_short_with_price_not_met;
-// }
+mod process_perpetual_order {
+    use super::*;
+    mod pending_limit_open_long_with_price_met;
+    mod pending_limit_open_long_with_price_not_met;
+    mod pending_limit_open_short_with_price_met;
+    mod pending_limit_open_short_with_price_not_met;
+}
 
 mod get_perpetual_order {
     use super::*;


### PR DESCRIPTION
## Changes

- [x] enable unit-tests

The market price was previously the price of `USDC` in terms of the `trading_asset`; now, it is indeed the price of the `trading_asset` in `USDC`.


## For Exemple

### Previously, to query the `market price`, we used the following method: getting the price of `USDC` in terms of `ATOM`
```sh
elysd q --output json --node "tcp://localhost:26657" wasm contract-state smart "elys17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgs98tvuy" '{
        "get_asset_price_from_denom_in_to_denom_out": {
            "denom_in": "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65",
            "denom_out": "ibc/E2D2F6ADCC68AA3384B2F5DFACCA437923D137C14E86FB8A10207CF3BED0C8D4"
        }
    }' 
```
```json
{
  "data": "0.105834831507643841"
}
```
### However, we are now using this query: getting the price of `ATOM` in terms of `USDC`:

```sh
 elysd q --output json --node "tcp://localhost:26657" wasm contract-state smart "elys17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgs98tvuy" '{
        "get_asset_price_from_denom_in_to_denom_out": {
            "denom_in": "ibc/E2D2F6ADCC68AA3384B2F5DFACCA437923D137C14E86FB8A10207CF3BED0C8D4",
            "denom_out": "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65"
        }
    }'
```
```json
{
  "data": "9.448685142261276681"
}
```

 