### PR TITLE
Masterchef fixes

### DIFF
--- a/bindings/src/account_history/msg/query_resp/estaking/get_estaking_rewards_response.rs
+++ b/bindings/src/account_history/msg/query_resp/estaking/get_estaking_rewards_response.rs
@@ -1,16 +1,16 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::DecCoin;
+use cosmwasm_std::Coin;
 
-use crate::account_history::types::Coin256Value;
+use crate::account_history::types::CoinValue;
 
 #[cw_serde]
 pub struct GetEstakingRewardsResponse {
-    pub rewards: Vec<(String, Coin256Value)>,
-    pub total: Vec<DecCoin>,
+    pub rewards: Vec<(String, CoinValue)>,
+    pub total: Vec<Coin>,
 }
 
 #[cw_serde]
 pub struct DelegationDelegatorReward {
     pub validator_address: String,
-    pub reward: Vec<Coin256Value>,
+    pub reward: Vec<CoinValue>,
 }

--- a/bindings/src/account_history/msg/query_resp/get_rewards_resp.rs
+++ b/bindings/src/account_history/msg/query_resp/get_rewards_resp.rs
@@ -1,9 +1,9 @@
-use crate::account_history::types::{Coin256Value, Reward};
+use crate::account_history::types::{CoinValue, Reward};
 
 use cosmwasm_schema::cw_serde;
 
 #[cw_serde]
 pub struct GetRewardsResp {
     pub rewards_map: Reward,
-    pub rewards: Vec<Coin256Value>,
+    pub rewards: Vec<CoinValue>,
 }

--- a/bindings/src/account_history/types/coin_value.rs
+++ b/bindings/src/account_history/types/coin_value.rs
@@ -1,8 +1,6 @@
-use std::str::FromStr;
-
 use crate::{query_resp::OracleAssetInfoResponse, types::OracleAssetInfo, ElysQuerier};
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Coin, DecCoin, Decimal, Decimal256, StdError, StdResult, Uint256};
+use cosmwasm_std::{Coin, Decimal, StdError, StdResult};
 
 #[cw_serde]
 #[derive(Default)]
@@ -11,15 +9,6 @@ pub struct CoinValue {
     pub amount_token: Decimal,
     pub price: Decimal,
     pub amount_usd: Decimal,
-}
-
-#[cw_serde]
-#[derive(Default)]
-pub struct Coin256Value {
-    pub denom: String,
-    pub amount_token: Decimal256,
-    pub price: Decimal,
-    pub amount_usd: Decimal256,
 }
 
 impl CoinValue {
@@ -79,75 +68,5 @@ impl CoinValue {
             price,
             amount_usd,
         })
-    }
-}
-
-impl Coin256Value {
-    pub fn new(
-        denom: String,
-        amount_token: Decimal256,
-        price: Decimal,
-        amount_usd: Decimal256,
-    ) -> Self {
-        Self {
-            denom,
-            amount_token,
-            amount_usd,
-            price,
-        }
-    }
-
-    pub fn from_coin256(balance: &Coin256, querier: &ElysQuerier<'_>) -> StdResult<Self> {
-        let OracleAssetInfoResponse { asset_info } = querier
-            .asset_info(balance.denom.clone())
-            .unwrap_or(OracleAssetInfoResponse {
-                asset_info: OracleAssetInfo {
-                    denom: balance.denom.clone(),
-                    display: balance.denom.clone(),
-                    band_ticker: balance.denom.clone(),
-                    elys_ticker: balance.denom.clone(),
-                    decimal: 6,
-                },
-            });
-        let decimal_point_token = asset_info.decimal;
-        let price = querier
-            .get_asset_price(balance.denom.clone())
-            .map_err(|e| StdError::generic_err(format!("failed to get_asset_price: {}", e)))?;
-
-        let amount_token = Decimal256::from_atomics(balance.amount, decimal_point_token as u32)
-            .map_err(|e| {
-                StdError::generic_err(format!("failed to convert amount to Decimal: {}", e))
-            })?;
-
-        let amount_usd = amount_token
-            .checked_mul(Decimal256::from(price.clone()))
-            .map_err(|e| {
-                StdError::generic_err(format!(
-                    "failed to convert amount_usd_base to Decimal: {}",
-                    e
-                ))
-            })?;
-
-        Ok(Self {
-            denom: balance.denom.clone(),
-            amount_token: Decimal256::from_str(balance.amount.to_string().as_str())?,
-            price,
-            amount_usd,
-        })
-    }
-}
-#[cw_serde]
-#[derive(Default)]
-pub struct Coin256 {
-    pub denom: String,
-    pub amount: Uint256,
-}
-
-impl From<DecCoin> for Coin256 {
-    fn from(value: DecCoin) -> Self {
-        Coin256 {
-            denom: value.denom,
-            amount: value.amount.atomics(),
-        }
     }
 }

--- a/bindings/src/account_history/types/earn_program/eden_boost_earn.rs
+++ b/bindings/src/account_history/types/earn_program/eden_boost_earn.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Uint128;
 
-use crate::account_history::types::{earn_detail::earn_detail::AprEdenBoost, Coin256Value};
+use crate::account_history::types::{earn_detail::earn_detail::AprEdenBoost, CoinValue};
 
 #[cw_serde]
 pub struct EdenBoostEarnProgram {
@@ -18,7 +18,7 @@ pub struct EdenBoostEarnProgram {
     // The rewards the user currently has on the Eden Boost Earn Program.
     // It should be in the response only if the address is in the request object.
     // rewards are either USDC or EDEN.
-    pub rewards: Option<Vec<Coin256Value>>,
+    pub rewards: Option<Vec<CoinValue>>,
 }
 
 // implement default

--- a/bindings/src/account_history/types/earn_program/eden_earn.rs
+++ b/bindings/src/account_history/types/earn_program/eden_earn.rs
@@ -1,5 +1,5 @@
 use crate::{
-    account_history::types::{AprElys, Coin256Value},
+    account_history::types::{AprElys, CoinValue},
     query_resp::StakedAvailable,
     trade_shield::types::BalanceAvailable,
     types::VestingDetail,
@@ -24,7 +24,7 @@ pub struct EdenEarnProgram {
     // It should be in the response only if the address is in the request object.
     // rewards are either USDC, EDEN or EDEN Boost.
     // Eden Boost doesnt have USD amount.
-    pub rewards: Option<Vec<Coin256Value>>,
+    pub rewards: Option<Vec<CoinValue>>,
     // The sum of all the total_vest.
     pub vesting: BalanceAvailable,
     // A list of all the vesting details for the EDEN program.

--- a/bindings/src/account_history/types/earn_program/elys_earn.rs
+++ b/bindings/src/account_history/types/earn_program/elys_earn.rs
@@ -1,5 +1,5 @@
 use crate::{
-    account_history::types::{AprElys, Coin256Value},
+    account_history::types::{AprElys, CoinValue},
     query_resp::StakedAvailable,
     types::{BalanceAvailable, StakedPosition, UnstakedPosition},
 };
@@ -21,7 +21,7 @@ pub struct ElysEarnProgram {
     // The rewards the user currently has on the Elys Earn Program.
     // It should be in the response only if the address is in the request object.
     // rewards are either USDC, EDEN or EDEN Boost.
-    pub rewards: Option<Vec<Coin256Value>>,
+    pub rewards: Option<Vec<CoinValue>>,
     // All the positions the user has staked on the ELYS program.
     // It should be in the response only if the address is in the request object.
     pub staked_positions: Option<Vec<StakedPosition>>,

--- a/bindings/src/account_history/types/mod.rs
+++ b/bindings/src/account_history/types/mod.rs
@@ -10,8 +10,6 @@ mod staked_assets;
 mod total_balance;
 
 pub use account_snapshot::AccountSnapshot;
-pub use coin_value::Coin256;
-pub use coin_value::Coin256Value;
 pub use coin_value::CoinValue;
 pub use metadata::Metadata;
 pub use portfolio_balance_snapshot::PortfolioBalanceSnapshot;

--- a/bindings/src/account_history/types/reward.rs
+++ b/bindings/src/account_history/types/reward.rs
@@ -1,24 +1,24 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Decimal256;
+use cosmwasm_std::Decimal;
 
 #[cw_serde]
 pub struct Reward {
-    pub usdc_usd: Decimal256,
-    pub eden_usd: Decimal256,
-    pub eden_boost: Decimal256,
-    pub other_usd: Decimal256,
-    pub total_usd: Decimal256,
+    pub usdc_usd: Decimal,
+    pub eden_usd: Decimal,
+    pub eden_boost: Decimal,
+    pub other_usd: Decimal,
+    pub total_usd: Decimal,
 }
 
 // implement default
 impl Default for Reward {
     fn default() -> Self {
         Self {
-            usdc_usd: Decimal256::zero(),
-            eden_usd: Decimal256::zero(),
-            eden_boost: Decimal256::zero(),
-            other_usd: Decimal256::zero(),
-            total_usd: Decimal256::zero(),
+            usdc_usd: Decimal::zero(),
+            eden_usd: Decimal::zero(),
+            eden_boost: Decimal::zero(),
+            other_usd: Decimal::zero(),
+            total_usd: Decimal::zero(),
         }
     }
 }

--- a/bindings/src/querier.rs
+++ b/bindings/src/querier.rs
@@ -383,7 +383,7 @@ impl<'a> ElysQuerier<'a> {
             .map(|stack| StakedPosition {
                 id: stack.id.clone(),
                 validator: StakingValidator {
-                    id: stack.validator.id.clone().map_or("".to_string(), |id| id),
+                    id: Some(stack.validator.id.clone().map_or("".to_string(), |id| id)),
                     address: stack
                         .validator
                         .address

--- a/bindings/src/query_resp.rs
+++ b/bindings/src/query_resp.rs
@@ -2,12 +2,12 @@ use std::{collections::HashMap, str::FromStr};
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    Coin, DecCoin, Decimal, Decimal256, Int128, SignedDecimal, SignedDecimal256, StdError,
-    StdResult, Uint128,
+    Coin, Decimal, Decimal256, Int128, SignedDecimal, SignedDecimal256, StdError, StdResult,
+    Uint128,
 };
 
 use crate::{
-    account_history::types::{Coin256, Coin256Value, CoinValue, ElysDenom},
+    account_history::types::{CoinValue, ElysDenom},
     trade_shield::types::{
         AmmPool, AmmPoolRaw, PerpetualPosition, PoolExtraInfo, StakedPositionRaw,
     },
@@ -711,14 +711,14 @@ pub struct MasterchefUserPendingRewardData {
 #[derive(Default)]
 pub struct EstakingRewardsResponse {
     pub rewards: Vec<DelegationDelegatorReward>,
-    pub total: Vec<DecCoin>,
+    pub total: Vec<Coin>,
 }
 
 #[cw_serde]
 #[derive(Default)]
 pub struct DelegationDelegatorReward {
     pub validator_address: String,
-    pub reward: Vec<DecCoin>,
+    pub reward: Vec<Coin>,
 }
 
 pub enum Validator {
@@ -772,39 +772,32 @@ impl EstakingRewardsResponse {
             total: self.total.clone(),
         }
     }
-    // TODO: to coinvalue
-    pub fn to_coin256_values(
-        &self,
-        querier: &ElysQuerier<'_>,
-    ) -> StdResult<Vec<(String, Coin256Value)>> {
-        let mut dec_coin_values = Vec::new();
+
+    pub fn to_coin_values(&self, querier: &ElysQuerier<'_>) -> StdResult<Vec<(String, CoinValue)>> {
+        let mut coin_values = Vec::new();
 
         for delegation_reward in &self.rewards {
             let validator_address = delegation_reward.validator_address.clone();
-            for dec_coin in &delegation_reward.reward {
-                if dec_coin.denom == ElysDenom::EdenBoost.as_str() {
-                    let eden_boost_coin = Coin256Value::new(
-                        dec_coin.denom.clone(),
-                        Decimal256::from_str(dec_coin.amount.to_string().as_str()).unwrap(),
+            for coin in &delegation_reward.reward {
+                if coin.denom == ElysDenom::EdenBoost.as_str() {
+                    let eden_boost_coin = CoinValue::new(
+                        coin.denom.clone(),
+                        Decimal::from_str(coin.amount.to_string().as_str()).unwrap(),
                         Decimal::zero(),
-                        Decimal256::zero(),
+                        Decimal::zero(),
                     );
-                    dec_coin_values.push((validator_address.clone(), eden_boost_coin));
+                    coin_values.push((validator_address.clone(), eden_boost_coin));
                     continue;
                 }
 
-                let dec_coin_value = Coin256Value::from_coin256(
-                    &Coin256::from(dec_coin.clone()),
-                    querier,
-                )
-                .map_err(|e| {
-                    StdError::generic_err(format!("Failed to convert to Coin256Value {}", e))
+                let coin_value = CoinValue::from_coin(&coin.clone(), querier).map_err(|e| {
+                    StdError::generic_err(format!("Failed to convert to CoinValue {}", e))
                 })?;
-                dec_coin_values.push((validator_address.clone(), dec_coin_value));
+                coin_values.push((validator_address.clone(), coin_value));
             }
         }
 
-        Ok(dec_coin_values)
+        Ok(coin_values)
     }
 }
 
@@ -814,33 +807,33 @@ impl MasterchefUserPendingRewardResponse {
         querier: &ElysQuerier<'_>,
     ) -> StdResult<(HashMap<u64, Vec<CoinValue>>, Vec<CoinValue>)> {
         Ok((
-            self.rewards_to_coins(querier)?,
+            self.rewards_to_coin_values(querier)?,
             self.total_rewards_to_coin(querier)?,
         ))
     }
 
-    pub fn rewards_to_coins(
+    pub fn rewards_to_coin_values(
         &self,
         querier: &ElysQuerier<'_>,
     ) -> StdResult<HashMap<u64, Vec<CoinValue>>> {
-        let mut dec_coin_values = HashMap::new();
+        let mut coin_values = HashMap::new();
         for MasterchefUserPendingRewardData { reward, pool_id } in &self.rewards {
-            let coin = { dec_coin_values.entry(*pool_id).or_insert_with(|| vec![]) };
+            let coin = { coin_values.entry(*pool_id).or_insert_with(|| vec![]) };
             coin.extend(
                 reward
                     .iter()
                     .map(|v| CoinValue::from_coin(v, querier).unwrap_or_default()),
             );
         }
-        Ok(dec_coin_values)
+        Ok(coin_values)
     }
 
     fn total_rewards_to_coin(&self, querier: &ElysQuerier<'_>) -> StdResult<Vec<CoinValue>> {
-        let mut dec_coin_values = Vec::new();
+        let mut coin_values = Vec::new();
         for reward in &self.total_rewards {
-            dec_coin_values.push(CoinValue::from_coin(reward, querier)?);
+            coin_values.push(CoinValue::from_coin(reward, querier)?);
         }
-        Ok(dec_coin_values)
+        Ok(coin_values)
     }
 }
 

--- a/bindings/src/query_resp.rs
+++ b/bindings/src/query_resp.rs
@@ -7,7 +7,7 @@ use cosmwasm_std::{
 };
 
 use crate::{
-    account_history::types::{CoinValue, ElysDenom},
+    account_history::types::CoinValue,
     trade_shield::types::{
         AmmPool, AmmPoolRaw, PerpetualPosition, PoolExtraInfo, StakedPositionRaw,
     },
@@ -779,17 +779,6 @@ impl EstakingRewardsResponse {
         for delegation_reward in &self.rewards {
             let validator_address = delegation_reward.validator_address.clone();
             for coin in &delegation_reward.reward {
-                if coin.denom == ElysDenom::EdenBoost.as_str() {
-                    let eden_boost_coin = CoinValue::new(
-                        coin.denom.clone(),
-                        Decimal::from_str(coin.amount.to_string().as_str()).unwrap(),
-                        Decimal::zero(),
-                        Decimal::zero(),
-                    );
-                    coin_values.push((validator_address.clone(), eden_boost_coin));
-                    continue;
-                }
-
                 let coin_value = CoinValue::from_coin(&coin.clone(), querier).map_err(|e| {
                     StdError::generic_err(format!("Failed to convert to CoinValue {}", e))
                 })?;

--- a/bindings/src/query_resp.rs
+++ b/bindings/src/query_resp.rs
@@ -444,10 +444,10 @@ pub struct QueryShowCommitmentsResponse {
 
 #[cw_serde]
 pub struct QueryAllProgramRewardsResponse {
-    pub usdc_staking_rewards: Vec<DecCoin>,
-    pub elys_staking_rewards: Vec<DecCoin>,
-    pub eden_staking_rewards: Vec<DecCoin>,
-    pub edenb_staking_rewards: Vec<DecCoin>,
+    pub usdc_staking_rewards: Vec<Coin>,
+    pub elys_staking_rewards: Vec<Coin>,
+    pub eden_staking_rewards: Vec<Coin>,
+    pub edenb_staking_rewards: Vec<Coin>,
 }
 
 #[cw_serde]

--- a/bindings/src/types.rs
+++ b/bindings/src/types.rs
@@ -488,7 +488,7 @@ pub struct ValidatorDetail {
 
     pub jailed: String,
 
-    pub inactive: String
+    pub inactive: String,
 }
 
 #[cw_serde]

--- a/bindings/src/types.rs
+++ b/bindings/src/types.rs
@@ -426,8 +426,8 @@ pub struct StakingValidatorRaw {
 
 #[cw_serde]
 pub struct StakingValidator {
-    // The validator Identity.
-    pub id: String,
+    // The validator Identity. Not all of them have the ID current returned by chain.
+    pub id: Option<String>,
     // The validator address.
     pub address: String,
     // The validator name.

--- a/contracts/account-history-contract/src/action/query/get_eden_boost_earn_program_details.rs
+++ b/contracts/account-history-contract/src/action/query/get_eden_boost_earn_program_details.rs
@@ -32,7 +32,7 @@ pub fn get_eden_boost_earn_program_details(
                 .unwrap_or_default();
             let program_rewards = all_rewards
                 .get_validator_rewards(Validator::EdenBoost)
-                .to_coin256_values(&querier)
+                .to_coin_values(&querier)
                 .unwrap_or_default()
                 .into_iter()
                 .map(|coin| coin.1)

--- a/contracts/account-history-contract/src/action/query/get_eden_earn_program_details.rs
+++ b/contracts/account-history-contract/src/action/query/get_eden_earn_program_details.rs
@@ -32,7 +32,7 @@ pub fn get_eden_earn_program_details(
                 .unwrap_or_default();
             let program_rewards = all_rewards
                 .get_validator_rewards(Validator::Eden)
-                .to_coin256_values(&querier)
+                .to_coin_values(&querier)
                 .unwrap_or_default()
                 .into_iter()
                 .map(|coin| coin.1)

--- a/contracts/account-history-contract/src/action/query/get_elys_earn_program_details.rs
+++ b/contracts/account-history-contract/src/action/query/get_elys_earn_program_details.rs
@@ -33,7 +33,7 @@ pub fn get_elys_earn_program_details(
                 .unwrap_or_default();
             let program_rewards = all_rewards
                 .get_elys_validators()
-                .to_coin256_values(&querier)
+                .to_coin_values(&querier)
                 .unwrap_or_default()
                 .into_iter()
                 .map(|coin| coin.1)

--- a/contracts/account-history-contract/src/action/query/get_estaking_rewards.rs
+++ b/contracts/account-history-contract/src/action/query/get_estaking_rewards.rs
@@ -13,12 +13,12 @@ pub fn get_estaking_rewards(
 
     let response = querier.get_estaking_rewards(address).unwrap_or_default();
 
-    let fiat_coins = response.to_coin256_values(&querier);
+    let fiat_coins = response.to_coin_values(&querier);
 
     match fiat_coins {
         Err(e) => {
             return Err(StdError::generic_err(format!(
-                "Failed to convert to Coin256Value {}",
+                "Failed to convert to CoinValue {}",
                 e
             )))
         }

--- a/contracts/account-history-contract/src/tests/get_all_pools.rs
+++ b/contracts/account-history-contract/src/tests/get_all_pools.rs
@@ -8,8 +8,7 @@ use crate::{
 };
 use anyhow::{bail, Error, Result as AnyResult};
 use cosmwasm_std::{
-    coin, coins, to_json_binary, Addr, Coin, DecCoin, Decimal, Decimal256, Empty, Int128, StdError,
-    Timestamp, Uint128,
+    coin, coins, to_json_binary, Addr, Coin, Decimal, Empty, Int128, StdError, Timestamp, Uint128,
 };
 use cw_multi_test::{AppResponse, BasicAppBuilder, ContractWrapper, Executor, Module};
 use elys_bindings::account_history::types::CoinValue;
@@ -111,37 +110,37 @@ impl Module for ElysModuleWrapper {
                 let resp = EstakingRewardsResponse {
                     rewards: vec![DelegationDelegatorReward {
                         validator_address: Validator::EdenBoost.to_string(),
-                        reward: vec![DecCoin {
+                        reward: vec![Coin {
                             denom: "ueden".to_string(),
-                            amount: Decimal256::from_str("1.21").unwrap(),
+                            amount: Uint128::from_str("121").unwrap(),
                         }],
                     }],
-                    total: vec![DecCoin {
+                    total: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("1.21").unwrap(),
+                        amount: Uint128::from_str("121").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
             }
             ElysQuery::IncentiveAllProgramRewards { .. } => {
                 let resp = QueryAllProgramRewardsResponse {
-                    usdc_staking_rewards: vec![DecCoin {
+                    usdc_staking_rewards: vec![Coin {
                         denom:
                             "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65"
                                 .to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    elys_staking_rewards: vec![DecCoin {
+                    elys_staking_rewards: vec![Coin {
                         denom: "uelys".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    eden_staking_rewards: vec![DecCoin {
+                    eden_staking_rewards: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    edenb_staking_rewards: vec![DecCoin {
+                    edenb_staking_rewards: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)

--- a/contracts/account-history-contract/src/tests/get_eden_boost_earn_program_details.rs
+++ b/contracts/account-history-contract/src/tests/get_eden_boost_earn_program_details.rs
@@ -7,14 +7,13 @@ use crate::{
 };
 use anyhow::{bail, Error, Result as AnyResult};
 use cosmwasm_std::{
-    coins, to_json_binary, Addr, Coin, DecCoin, Decimal, Decimal256, Empty, Int128, StdError,
-    Timestamp, Uint128,
+    coins, to_json_binary, Addr, Coin, Decimal, Empty, Int128, StdError, Timestamp, Uint128,
 };
 use cw_multi_test::{AppResponse, BasicAppBuilder, ContractWrapper, Executor, Module};
 use elys_bindings::account_history::msg::query_resp::earn::GetEdenBoostEarnProgramResp;
 use elys_bindings::account_history::types::earn_detail::earn_detail::AprEdenBoost;
 use elys_bindings::account_history::types::earn_program::EdenBoostEarnProgram;
-use elys_bindings::account_history::types::Coin256Value;
+use elys_bindings::account_history::types::CoinValue;
 use elys_bindings::query_resp::{
     BalanceBorrowed, DelegationDelegatorReward, EstakingRewardsResponse,
     MasterchefUserPendingRewardData, MasterchefUserPendingRewardResponse,
@@ -128,35 +127,35 @@ impl Module for ElysModuleWrapper {
                 let resp = EstakingRewardsResponse {
                     rewards: vec![DelegationDelegatorReward {
                         validator_address: Validator::EdenBoost.to_string(),
-                        reward: vec![DecCoin {
+                        reward: vec![Coin {
                             denom: "ueden".to_string(),
-                            amount: Decimal256::from_str("1.21").unwrap(),
+                            amount: Uint128::from_str("121").unwrap(),
                         }],
                     }],
-                    total: vec![DecCoin {
+                    total: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("1.21").unwrap(),
+                        amount: Uint128::from_str("121").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
             }
             ElysQuery::IncentiveAllProgramRewards { .. } => {
                 let resp = QueryAllProgramRewardsResponse {
-                    usdc_staking_rewards: vec![DecCoin {
+                    usdc_staking_rewards: vec![Coin {
                         denom: "usdc".to_string(),
-                        amount: Decimal256::from_str("123.1").unwrap(),
+                        amount: Uint128::from_str("1231").unwrap(),
                     }],
-                    elys_staking_rewards: vec![DecCoin {
+                    elys_staking_rewards: vec![Coin {
                         denom: "uelys".to_string(),
-                        amount: Decimal256::zero(),
+                        amount: Uint128::zero(),
                     }],
-                    eden_staking_rewards: vec![DecCoin {
+                    eden_staking_rewards: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::zero(),
+                        amount: Uint128::zero(),
                     }],
-                    edenb_staking_rewards: vec![DecCoin {
+                    edenb_staking_rewards: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::zero(),
+                        amount: Uint128::zero(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
@@ -305,11 +304,11 @@ fn get_eden_boost_earn_program_details() {
             },
             available: Some(Uint128::new(21798000)),
             staked: Some(Uint128::new(100120000000)),
-            rewards: Some(vec![Coin256Value {
+            rewards: Some(vec![CoinValue {
                 denom: "ueden".to_string(),
-                amount_token: Decimal256::from_str("1210000000000000000").unwrap(),
-                price: Decimal::from_atomics(Uint128::new(35308010067676894), 16).unwrap(),
-                amount_usd: Decimal256::from_str("4272269218188.904174").unwrap(),
+                amount_token: Decimal::from_str("0.000121").unwrap(),
+                price: Decimal::from_str("3.5308010067676894").unwrap(),
+                amount_usd: Decimal::from_str("0.00042722692181889").unwrap(),
             }]),
         },
     };

--- a/contracts/account-history-contract/src/tests/get_eden_earn_program_details.rs
+++ b/contracts/account-history-contract/src/tests/get_eden_earn_program_details.rs
@@ -7,13 +7,12 @@ use crate::{
 };
 use anyhow::{bail, Error, Result as AnyResult};
 use cosmwasm_std::{
-    coins, to_json_binary, Addr, Coin, DecCoin, Decimal, Decimal256, Empty, Int128, StdError,
-    Timestamp, Uint128,
+    coins, to_json_binary, Addr, Coin, Decimal, Empty, Int128, StdError, Timestamp, Uint128,
 };
 use cw_multi_test::{AppResponse, BasicAppBuilder, ContractWrapper, Executor, Module};
 use elys_bindings::account_history::msg::query_resp::earn::GetEdenEarnProgramResp;
 use elys_bindings::account_history::types::earn_program::EdenEarnProgram;
-use elys_bindings::account_history::types::{AprElys, Coin256Value};
+use elys_bindings::account_history::types::{AprElys, CoinValue};
 use elys_bindings::query_resp::{
     BalanceBorrowed, DelegationDelegatorReward, EstakingRewardsResponse,
     MasterchefUserPendingRewardData, MasterchefUserPendingRewardResponse,
@@ -128,35 +127,35 @@ impl Module for ElysModuleWrapper {
                     rewards: vec![DelegationDelegatorReward {
                         validator_address: "elysvaloper1gnmpr8vvslp3shcq6e922xr0uq4aa2w5gdzht0"
                             .to_string(),
-                        reward: vec![DecCoin {
+                        reward: vec![Coin {
                             denom: "ueden".to_string(),
-                            amount: Decimal256::from_str("1.21").unwrap(),
+                            amount: Uint128::from_str("121").unwrap(),
                         }],
                     }],
-                    total: vec![DecCoin {
+                    total: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::from_str("1.21").unwrap(),
+                        amount: Uint128::from_str("121").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
             }
             ElysQuery::IncentiveAllProgramRewards { .. } => {
                 let resp = QueryAllProgramRewardsResponse {
-                    usdc_staking_rewards: vec![DecCoin {
+                    usdc_staking_rewards: vec![Coin {
                         denom: "usdc".to_string(),
-                        amount: Decimal256::from_str("123.1").unwrap(),
+                        amount: Uint128::from_str("1231").unwrap(),
                     }],
-                    elys_staking_rewards: vec![DecCoin {
+                    elys_staking_rewards: vec![Coin {
                         denom: "uelys".to_string(),
-                        amount: Decimal256::zero(),
+                        amount: Uint128::zero(),
                     }],
-                    eden_staking_rewards: vec![DecCoin {
+                    eden_staking_rewards: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::zero(),
+                        amount: Uint128::zero(),
                     }],
-                    edenb_staking_rewards: vec![DecCoin {
+                    edenb_staking_rewards: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::zero(),
+                        amount: Uint128::zero(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
@@ -313,11 +312,11 @@ fn get_eden_earn_program_details() {
                 amount: Uint128::new(100120000000),
                 lockups: None,
             }),
-            rewards: Some(vec![Coin256Value {
+            rewards: Some(vec![CoinValue {
                 denom: "ueden".to_string(),
-                amount_token: Decimal256::from_str("1210000000000000000").unwrap(),
-                price: Decimal::from_atomics(Uint128::new(35308010067676894), 16).unwrap(),
-                amount_usd: Decimal256::from_str("4272269218188.904174").unwrap(),
+                amount_token: Decimal::from_str("0.000121").unwrap(),
+                price: Decimal::from_str("3.5308010067676894").unwrap(),
+                amount_usd: Decimal::from_str("0.00042722692181889").unwrap(),
             }]),
             vesting: BalanceAvailable {
                 amount: Uint128::from_str("100").unwrap(),

--- a/contracts/account-history-contract/src/tests/get_elys_earn_program_detail.rs
+++ b/contracts/account-history-contract/src/tests/get_elys_earn_program_detail.rs
@@ -7,13 +7,12 @@ use crate::{
 };
 use anyhow::{bail, Error, Result as AnyResult};
 use cosmwasm_std::{
-    coins, to_json_binary, Addr, Coin, DecCoin, Decimal, Decimal256, Empty, Int128, StdError,
-    Timestamp, Uint128,
+    coins, to_json_binary, Addr, Coin, Decimal, Empty, Int128, StdError, Timestamp, Uint128,
 };
 use cw_multi_test::{AppResponse, BasicAppBuilder, ContractWrapper, Executor, Module};
 use elys_bindings::account_history::msg::query_resp::earn::GetElysEarnProgramResp;
 use elys_bindings::account_history::types::earn_program::ElysEarnProgram;
-use elys_bindings::account_history::types::{AprElys, Coin256Value};
+use elys_bindings::account_history::types::{AprElys, CoinValue};
 use elys_bindings::query_resp::{
     BalanceBorrowed, DelegationDelegatorReward, EstakingRewardsResponse,
     MasterchefUserPendingRewardData, MasterchefUserPendingRewardResponse,
@@ -127,35 +126,35 @@ impl Module for ElysModuleWrapper {
                 let resp = EstakingRewardsResponse {
                     rewards: vec![DelegationDelegatorReward {
                         validator_address: "validator".to_string(),
-                        reward: vec![DecCoin {
+                        reward: vec![Coin {
                             denom: "ueden".to_string(),
-                            amount: Decimal256::from_str("1.21").unwrap(),
+                            amount: Uint128::from_str("121").unwrap(),
                         }],
                     }],
-                    total: vec![DecCoin {
+                    total: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::from_str("1.21").unwrap(),
+                        amount: Uint128::from_str("121").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
             }
             ElysQuery::IncentiveAllProgramRewards { .. } => {
                 let resp = QueryAllProgramRewardsResponse {
-                    usdc_staking_rewards: vec![DecCoin {
+                    usdc_staking_rewards: vec![Coin {
                         denom: "usdc".to_string(),
-                        amount: Decimal256::from_str("123.1").unwrap(),
+                        amount: Uint128::from_str("1231").unwrap(),
                     }],
-                    elys_staking_rewards: vec![DecCoin {
+                    elys_staking_rewards: vec![Coin {
                         denom: "uelys".to_string(),
-                        amount: Decimal256::zero(),
+                        amount: Uint128::zero(),
                     }],
-                    eden_staking_rewards: vec![DecCoin {
+                    eden_staking_rewards: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::zero(),
+                        amount: Uint128::zero(),
                     }],
-                    edenb_staking_rewards: vec![DecCoin {
+                    edenb_staking_rewards: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::zero(),
+                        amount: Uint128::zero(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
@@ -312,11 +311,11 @@ fn get_elys_earn_program_details() {
                 amount: Uint128::new(100120000000),
                 lockups: None,
             }),
-            rewards: Some(vec![Coin256Value {
+            rewards: Some(vec![CoinValue {
                 denom: "ueden".to_string(),
-                amount_token: Decimal256::from_str("1210000000000000000").unwrap(),
-                price: Decimal::from_atomics(Uint128::new(35308010067676894), 16).unwrap(),
-                amount_usd: Decimal256::from_str("4272269218188.904174").unwrap(),
+                amount_token: Decimal::from_str("0.000121").unwrap(),
+                price: Decimal::from_str("3.5308010067676894").unwrap(),
+                amount_usd: Decimal::from_str("0.00042722692181889").unwrap(),
             }]),
             staked_positions: None,
             unstaked_positions: None,

--- a/contracts/account-history-contract/src/tests/get_liquid_assets.rs
+++ b/contracts/account-history-contract/src/tests/get_liquid_assets.rs
@@ -211,14 +211,14 @@ impl Module for ElysModuleWrapper {
                 let resp = EstakingRewardsResponse {
                     rewards: vec![DelegationDelegatorReward {
                         validator_address: Validator::EdenBoost.to_string(),
-                        reward: vec![DecCoin {
+                        reward: vec![Coin {
                             denom: "ueden".to_string(),
-                            amount: Decimal256::from_str("1.21").unwrap(),
+                            amount: Uint128::from_str("121").unwrap(),
                         }],
                     }],
-                    total: vec![DecCoin {
+                    total: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("1.21").unwrap(),
+                        amount: Uint128::from_str("121").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
@@ -270,23 +270,23 @@ impl Module for ElysModuleWrapper {
             }
             ElysQuery::IncentiveAllProgramRewards { .. } => {
                 let resp = QueryAllProgramRewardsResponse {
-                    usdc_staking_rewards: vec![DecCoin {
+                    usdc_staking_rewards: vec![Coin {
                         denom:
                             "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65"
                                 .to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    elys_staking_rewards: vec![DecCoin {
+                    elys_staking_rewards: vec![Coin {
                         denom: "uelys".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    eden_staking_rewards: vec![DecCoin {
+                    eden_staking_rewards: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    edenb_staking_rewards: vec![DecCoin {
+                    edenb_staking_rewards: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)

--- a/contracts/account-history-contract/src/tests/get_rewards.rs
+++ b/contracts/account-history-contract/src/tests/get_rewards.rs
@@ -14,8 +14,7 @@ use elys_bindings::account_history::msg::query_resp::GetRewardsResp;
 use elys_bindings::account_history::types::{CoinValue, Reward};
 use elys_bindings::query_resp::{
     DelegationDelegatorReward, EstakingRewardsResponse, MasterchefUserPendingRewardData,
-    MasterchefUserPendingRewardResponse, QueryAllProgramRewardsResponse,
-    QueryStableStakeAprResponse, Validator,
+    MasterchefUserPendingRewardResponse, QueryStableStakeAprResponse, Validator,
 };
 use elys_bindings::types::BalanceAvailable;
 use elys_bindings::{ElysMsg, ElysQuery};
@@ -122,30 +121,6 @@ impl Module for ElysModuleWrapper {
                 };
                 Ok(to_json_binary(&resp)?)
             }
-            ElysQuery::IncentiveAllProgramRewards { .. } => {
-                let resp = QueryAllProgramRewardsResponse {
-                    usdc_staking_rewards: vec![Coin {
-                        denom:
-                            "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65"
-                                .to_string(),
-                        amount: Uint128::zero(),
-                    }],
-                    elys_staking_rewards: vec![Coin {
-                        denom: "uelys".to_string(),
-                        amount: Uint128::zero(),
-                    }],
-                    eden_staking_rewards: vec![Coin {
-                        denom: "ueden".to_string(),
-                        amount: Uint128::zero(),
-                    }],
-                    edenb_staking_rewards: vec![Coin {
-                        denom: "uedenb".to_string(),
-                        amount: Uint128::zero(),
-                    }],
-                };
-                Ok(to_json_binary(&resp)?)
-            }
-
             _ => self.0.query(api, storage, querier, block, request),
         }
     }
@@ -280,40 +255,31 @@ fn get_rewards() {
         )
         .unwrap();
 
-    assert_eq!(resp.rewards_map, Reward::default());
     assert_eq!(
-        resp.rewards.contains(&CoinValue {
-            denom: "uelys".to_string(),
-            amount_token: Decimal::zero(),
-            price: Decimal::from_str("3.5308010067676894").unwrap(),
-            amount_usd: Decimal::zero(),
-        }),
-        true
+        resp.rewards_map,
+        Reward {
+            usdc_usd: Decimal::zero(),
+            eden_usd: Decimal::from_str("0.000070616020135353").unwrap(),
+            eden_boost: Decimal::from_str("0.000121").unwrap(),
+            other_usd: Decimal::zero(),
+            total_usd: Decimal::from_str("0.000070616020135353").unwrap()
+        }
     );
-    assert_eq!(
-        resp.rewards.contains(&CoinValue {
-            denom: "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65"
-                .to_string(),
-            amount_token: Decimal::zero(),
-            price: Decimal::from_str("1").unwrap(),
-            amount_usd: Decimal::zero(),
-        }),
-        true
-    );
+
     assert_eq!(
         resp.rewards.contains(&CoinValue {
             denom: "ueden".to_string(),
-            amount_token: Decimal::zero(),
+            amount_token: Decimal::from_str("0.00002").unwrap(),
             price: Decimal::from_str("3.5308010067676894").unwrap(),
-            amount_usd: Decimal::zero(),
+            amount_usd: Decimal::from_str("0.000070616020135353").unwrap(),
         }),
         true
     );
     assert_eq!(
         resp.rewards.contains(&CoinValue {
             denom: "uedenb".to_string(),
-            amount_token: Decimal::zero(),
-            price: Decimal::from_str("0").unwrap(),
+            amount_token: Decimal::from_str("0.000121").unwrap(),
+            price: Decimal::zero(),
             amount_usd: Decimal::zero(),
         }),
         true

--- a/contracts/account-history-contract/src/tests/get_rewards.rs
+++ b/contracts/account-history-contract/src/tests/get_rewards.rs
@@ -7,12 +7,11 @@ use crate::{
 };
 use anyhow::{bail, Error, Result as AnyResult};
 use cosmwasm_std::{
-    coins, to_json_binary, Addr, Coin, DecCoin, Decimal, Decimal256, Empty, Int128, StdError,
-    Timestamp, Uint128,
+    coins, to_json_binary, Addr, Coin, Decimal, Empty, Int128, StdError, Timestamp, Uint128,
 };
 use cw_multi_test::{AppResponse, BasicAppBuilder, ContractWrapper, Executor, Module};
 use elys_bindings::account_history::msg::query_resp::GetRewardsResp;
-use elys_bindings::account_history::types::{Coin256Value, Reward};
+use elys_bindings::account_history::types::{CoinValue, Reward};
 use elys_bindings::query_resp::{
     DelegationDelegatorReward, EstakingRewardsResponse, MasterchefUserPendingRewardData,
     MasterchefUserPendingRewardResponse, QueryAllProgramRewardsResponse,
@@ -111,37 +110,37 @@ impl Module for ElysModuleWrapper {
                 let resp = EstakingRewardsResponse {
                     rewards: vec![DelegationDelegatorReward {
                         validator_address: Validator::EdenBoost.to_string(),
-                        reward: vec![DecCoin {
+                        reward: vec![Coin {
                             denom: "ueden".to_string(),
-                            amount: Decimal256::from_str("1.21").unwrap(),
+                            amount: Uint128::from_str("121").unwrap(),
                         }],
                     }],
-                    total: vec![DecCoin {
+                    total: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("1.21").unwrap(),
+                        amount: Uint128::from_str("121").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
             }
             ElysQuery::IncentiveAllProgramRewards { .. } => {
                 let resp = QueryAllProgramRewardsResponse {
-                    usdc_staking_rewards: vec![DecCoin {
+                    usdc_staking_rewards: vec![Coin {
                         denom:
                             "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65"
                                 .to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::zero(),
                     }],
-                    elys_staking_rewards: vec![DecCoin {
+                    elys_staking_rewards: vec![Coin {
                         denom: "uelys".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::zero(),
                     }],
-                    eden_staking_rewards: vec![DecCoin {
+                    eden_staking_rewards: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::zero(),
                     }],
-                    edenb_staking_rewards: vec![DecCoin {
+                    edenb_staking_rewards: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::zero(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
@@ -283,39 +282,39 @@ fn get_rewards() {
 
     assert_eq!(resp.rewards_map, Reward::default());
     assert_eq!(
-        resp.rewards.contains(&Coin256Value {
+        resp.rewards.contains(&CoinValue {
             denom: "uelys".to_string(),
-            amount_token: Decimal256::zero(),
+            amount_token: Decimal::zero(),
             price: Decimal::from_str("3.5308010067676894").unwrap(),
-            amount_usd: Decimal256::zero(),
+            amount_usd: Decimal::zero(),
         }),
         true
     );
     assert_eq!(
-        resp.rewards.contains(&Coin256Value {
+        resp.rewards.contains(&CoinValue {
             denom: "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65"
                 .to_string(),
-            amount_token: Decimal256::zero(),
+            amount_token: Decimal::zero(),
             price: Decimal::from_str("1").unwrap(),
-            amount_usd: Decimal256::zero(),
+            amount_usd: Decimal::zero(),
         }),
         true
     );
     assert_eq!(
-        resp.rewards.contains(&Coin256Value {
+        resp.rewards.contains(&CoinValue {
             denom: "ueden".to_string(),
-            amount_token: Decimal256::zero(),
+            amount_token: Decimal::zero(),
             price: Decimal::from_str("3.5308010067676894").unwrap(),
-            amount_usd: Decimal256::zero(),
+            amount_usd: Decimal::zero(),
         }),
         true
     );
     assert_eq!(
-        resp.rewards.contains(&Coin256Value {
+        resp.rewards.contains(&CoinValue {
             denom: "uedenb".to_string(),
-            amount_token: Decimal256::zero(),
+            amount_token: Decimal::zero(),
             price: Decimal::from_str("0").unwrap(),
-            amount_usd: Decimal256::zero(),
+            amount_usd: Decimal::zero(),
         }),
         true
     );

--- a/contracts/account-history-contract/src/tests/get_staked_assets.rs
+++ b/contracts/account-history-contract/src/tests/get_staked_assets.rs
@@ -256,7 +256,7 @@ impl Module for ElysModuleWrapper {
                         staked_position: Some(vec![StakedPosition {
                             id: "2".to_string(),
                             validator: StakingValidator {
-                                id: String::from("1"),
+                                id: Some(String::from("1")),
                                 address: "elysvaloper1ng8sen6z5xzcfjtyrsedpe43hglymq040x3cpw"
                                     .to_string(),
                                 name: "nirvana".to_string(),
@@ -279,7 +279,7 @@ impl Module for ElysModuleWrapper {
                         unstaked_position: Some(vec![UnstakedPosition {
                             id: "1".to_string(),
                             validator: StakingValidator {
-                                id: String::from("1"),
+                                id: Some(String::from("1")),
                                 address: "elysvaloper1ng8sen6z5xzcfjtyrsedpe43hglymq040x3cpw"
                                     .to_string(),
                                 name: "nirvana".to_string(),
@@ -648,7 +648,7 @@ fn get_staked_assets() {
         unstaking: vec![UnstakedPosition {
             id: "1".to_string(),
             validator: StakingValidator {
-                id: String::from("1"),
+                id: Some(String::from("1")),
                 address: "elysvaloper1ng8sen6z5xzcfjtyrsedpe43hglymq040x3cpw".to_string(),
                 name: "nirvana".to_string(),
                 voting_power: Decimal::from_str("25.6521469796402094").unwrap(),
@@ -737,7 +737,7 @@ fn get_staked_assets() {
                 staked_positions: Some(vec![StakedPosition {
                     id: "2".to_string(),
                     validator: StakingValidator {
-                        id: "1".to_string(),
+                        id: Some("1".to_string()),
                         address: "elysvaloper1ng8sen6z5xzcfjtyrsedpe43hglymq040x3cpw".to_string(),
                         name: "nirvana".to_string(),
                         voting_power: Decimal::from_str("25.6521469796402094").unwrap(),
@@ -751,7 +751,7 @@ fn get_staked_assets() {
                 unstaked_positions: Some(vec![UnstakedPosition {
                     id: "1".to_string(),
                     validator: StakingValidator {
-                        id: "1".to_string(),
+                        id: Some("1".to_string()),
                         address: "elysvaloper1ng8sen6z5xzcfjtyrsedpe43hglymq040x3cpw".to_string(),
                         name: "nirvana".to_string(),
                         voting_power: Decimal::from_str("25.6521469796402094").unwrap(),

--- a/contracts/account-history-contract/src/tests/get_staked_assets.rs
+++ b/contracts/account-history-contract/src/tests/get_staked_assets.rs
@@ -18,7 +18,7 @@ use elys_bindings::account_history::types::earn_program::{
     EdenBoostEarnProgram, EdenEarnProgram, ElysEarnProgram, UsdcEarnProgram,
 };
 use elys_bindings::account_history::types::{
-    AprElys, AprUsdc, Coin256Value, CoinValue, QueryAprResponse, StakedAssets,
+    AprElys, AprUsdc, CoinValue, QueryAprResponse, StakedAssets,
 };
 use elys_bindings::query_resp::{
     BalanceBorrowed, DelegationDelegatorReward, Entry, EstakingRewardsResponse, Lockup,
@@ -141,14 +141,14 @@ impl Module for ElysModuleWrapper {
                 let resp = EstakingRewardsResponse {
                     rewards: vec![DelegationDelegatorReward {
                         validator_address: Validator::EdenBoost.to_string(),
-                        reward: vec![DecCoin {
+                        reward: vec![Coin {
                             denom: "ueden".to_string(),
-                            amount: Decimal256::from_str("1.21").unwrap(),
+                            amount: Uint128::from_str("121").unwrap(),
                         }],
                     }],
-                    total: vec![DecCoin {
+                    total: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("1.21").unwrap(),
+                        amount: Uint128::from_str("121").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
@@ -487,23 +487,23 @@ impl Module for ElysModuleWrapper {
             }
             ElysQuery::IncentiveAllProgramRewards { .. } => {
                 let resp = QueryAllProgramRewardsResponse {
-                    usdc_staking_rewards: vec![DecCoin {
+                    usdc_staking_rewards: vec![Coin {
                         denom:
                             "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65"
                                 .to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    elys_staking_rewards: vec![DecCoin {
+                    elys_staking_rewards: vec![Coin {
                         denom: "uelys".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    eden_staking_rewards: vec![DecCoin {
+                    eden_staking_rewards: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    edenb_staking_rewards: vec![DecCoin {
+                    edenb_staking_rewards: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
@@ -684,11 +684,11 @@ fn get_staked_assets() {
                 },
                 available: Some(Uint128::zero()),
                 staked: Some(Uint128::zero()),
-                rewards: Some(vec![Coin256Value {
+                rewards: Some(vec![CoinValue {
                     denom: "ueden".to_string(),
-                    amount_token: Decimal256::from_str("1210000000000000000").unwrap(),
+                    amount_token: Decimal::from_str("0.000121").unwrap(),
                     price: Decimal::from_atomics(Uint128::new(35308010067676894), 16).unwrap(),
-                    amount_usd: Decimal256::from_str("4272269218188.904174").unwrap(),
+                    amount_usd: Decimal::from_str("0.00042722692181889").unwrap(),
                 }]),
             },
             eden_earn_program: EdenEarnProgram {

--- a/contracts/account-history-contract/src/tests/get_usdc_earn_program_details.rs
+++ b/contracts/account-history-contract/src/tests/get_usdc_earn_program_details.rs
@@ -7,8 +7,7 @@ use crate::{
 };
 use anyhow::{bail, Error, Result as AnyResult};
 use cosmwasm_std::{
-    coins, to_json_binary, Addr, Coin, DecCoin, Decimal, Decimal256, Empty, Int128, StdError,
-    Timestamp, Uint128,
+    coins, to_json_binary, Addr, Coin, Decimal, Empty, Int128, StdError, Timestamp, Uint128,
 };
 use cw_multi_test::{AppResponse, BasicAppBuilder, ContractWrapper, Executor, Module};
 use elys_bindings::account_history::msg::query_resp::earn::GetUsdcEarnProgramResp;
@@ -127,35 +126,35 @@ impl Module for ElysModuleWrapper {
                 let resp = EstakingRewardsResponse {
                     rewards: vec![DelegationDelegatorReward {
                         validator_address: "validator".to_string(),
-                        reward: vec![DecCoin {
+                        reward: vec![Coin {
                             denom: "ueden".to_string(),
-                            amount: Decimal256::from_str("1.21").unwrap(),
+                            amount: Uint128::from_str("121").unwrap(),
                         }],
                     }],
-                    total: vec![DecCoin {
+                    total: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::from_str("1.21").unwrap(),
+                        amount: Uint128::from_str("121").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
             }
             ElysQuery::IncentiveAllProgramRewards { .. } => {
                 let resp = QueryAllProgramRewardsResponse {
-                    usdc_staking_rewards: vec![DecCoin {
+                    usdc_staking_rewards: vec![Coin {
                         denom: "usdc".to_string(),
-                        amount: Decimal256::from_str("123.1").unwrap(),
+                        amount: Uint128::from_str("1231").unwrap(),
                     }],
-                    elys_staking_rewards: vec![DecCoin {
+                    elys_staking_rewards: vec![Coin {
                         denom: "uelys".to_string(),
-                        amount: Decimal256::zero(),
+                        amount: Uint128::zero(),
                     }],
-                    eden_staking_rewards: vec![DecCoin {
+                    eden_staking_rewards: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::zero(),
+                        amount: Uint128::zero(),
                     }],
-                    edenb_staking_rewards: vec![DecCoin {
+                    edenb_staking_rewards: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::zero(),
+                        amount: Uint128::zero(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)

--- a/contracts/account-history-contract/src/tests/update_accounts.rs
+++ b/contracts/account-history-contract/src/tests/update_accounts.rs
@@ -19,7 +19,7 @@ use trade_shield_contract::types::{OrderPrice, SpotOrderType};
 use crate::entry_point::instantiate;
 use crate::entry_point::{execute, query, sudo};
 use anyhow::{bail, Error, Result as AnyResult};
-use cosmwasm_std::{to_json_binary, DecCoin, Empty, Int128, SignedDecimal, StdError, Uint128};
+use cosmwasm_std::{to_json_binary, Empty, Int128, SignedDecimal, StdError, Uint128};
 use cw_multi_test::{AppResponse, Module};
 
 use elys_bindings::query_resp::{
@@ -240,14 +240,14 @@ impl Module for ElysModuleWrapper {
                 let resp = EstakingRewardsResponse {
                     rewards: vec![DelegationDelegatorReward {
                         validator_address: Validator::EdenBoost.to_string(),
-                        reward: vec![DecCoin {
+                        reward: vec![Coin {
                             denom: "ueden".to_string(),
-                            amount: Decimal256::from_str("1.21").unwrap(),
+                            amount: Uint128::from_str("121").unwrap(),
                         }],
                     }],
-                    total: vec![DecCoin {
+                    total: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("1.21").unwrap(),
+                        amount: Uint128::from_str("121").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
@@ -276,23 +276,23 @@ impl Module for ElysModuleWrapper {
             }
             ElysQuery::IncentiveAllProgramRewards { .. } => {
                 let resp = QueryAllProgramRewardsResponse {
-                    usdc_staking_rewards: vec![DecCoin {
+                    usdc_staking_rewards: vec![Coin {
                         denom:
                             "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65"
                                 .to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    elys_staking_rewards: vec![DecCoin {
+                    elys_staking_rewards: vec![Coin {
                         denom: "uelys".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    eden_staking_rewards: vec![DecCoin {
+                    eden_staking_rewards: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    edenb_staking_rewards: vec![DecCoin {
+                    edenb_staking_rewards: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
@@ -460,7 +460,7 @@ fn history() {
 
     assert_eq!(
         res.value.total_balance_usd,
-        Decimal256::from_str("400.0010347342").unwrap(),
+        Decimal256::from_str("400.00111371648").unwrap(),
     );
 
     app.sudo(AppSudo::Bank(BankSudo::Mint {
@@ -482,6 +482,6 @@ fn history() {
 
     assert_eq!(
         res.value.total_balance_usd,
-        Decimal256::from_str("400.0010347342").unwrap(),
+        Decimal256::from_str("400.00111371648").unwrap(),
     ); // The previous value wasn't removed yet but wasn't read either since it's expired.
 }

--- a/contracts/account-history-contract/src/tests/update_accounts.rs
+++ b/contracts/account-history-contract/src/tests/update_accounts.rs
@@ -460,7 +460,7 @@ fn history() {
 
     assert_eq!(
         res.value.total_balance_usd,
-        Decimal256::from_str("400.00111371648").unwrap(),
+        Decimal256::from_str("400.00110371648").unwrap(),
     );
 
     app.sudo(AppSudo::Bank(BankSudo::Mint {
@@ -482,6 +482,6 @@ fn history() {
 
     assert_eq!(
         res.value.total_balance_usd,
-        Decimal256::from_str("400.00111371648").unwrap(),
+        Decimal256::from_str("400.00110371648").unwrap(),
     ); // The previous value wasn't removed yet but wasn't read either since it's expired.
 }

--- a/contracts/account-history-contract/src/tests/week_snapshots.rs
+++ b/contracts/account-history-contract/src/tests/week_snapshots.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use anyhow::{bail, Error, Result as AnyResult};
 use cosmwasm_std::{
-    coin, coins, to_json_binary, Addr, BlockInfo, Coin, DecCoin, Decimal, Decimal256, Empty,
-    Int128, SignedDecimal, StdError, Timestamp, Uint128,
+    coin, coins, to_json_binary, Addr, BlockInfo, Coin, Decimal, Empty, Int128, SignedDecimal,
+    StdError, Timestamp, Uint128,
 };
 use cw_multi_test::{AppResponse, BankSudo, BasicAppBuilder, ContractWrapper, Executor, Module};
 use cw_utils::Expiration;
@@ -230,14 +230,14 @@ impl Module for ElysModuleWrapper {
                 let resp = EstakingRewardsResponse {
                     rewards: vec![DelegationDelegatorReward {
                         validator_address: Validator::EdenBoost.to_string(),
-                        reward: vec![DecCoin {
+                        reward: vec![Coin {
                             denom: "ueden".to_string(),
-                            amount: Decimal256::from_str("1.21").unwrap(),
+                            amount: Uint128::from_str("121").unwrap(),
                         }],
                     }],
-                    total: vec![DecCoin {
+                    total: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("1.21").unwrap(),
+                        amount: Uint128::from_str("121").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)
@@ -266,23 +266,23 @@ impl Module for ElysModuleWrapper {
             }
             ElysQuery::IncentiveAllProgramRewards { .. } => {
                 let resp = QueryAllProgramRewardsResponse {
-                    usdc_staking_rewards: vec![DecCoin {
+                    usdc_staking_rewards: vec![Coin {
                         denom:
                             "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65"
                                 .to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    elys_staking_rewards: vec![DecCoin {
+                    elys_staking_rewards: vec![Coin {
                         denom: "uelys".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    eden_staking_rewards: vec![DecCoin {
+                    eden_staking_rewards: vec![Coin {
                         denom: "ueden".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
-                    edenb_staking_rewards: vec![DecCoin {
+                    edenb_staking_rewards: vec![Coin {
                         denom: "uedenb".to_string(),
-                        amount: Decimal256::from_str("10").unwrap(),
+                        amount: Uint128::from_str("10").unwrap(),
                     }],
                 };
                 Ok(to_json_binary(&resp)?)

--- a/contracts/account-history-contract/src/types/account_snapshot_generator.rs
+++ b/contracts/account-history-contract/src/types/account_snapshot_generator.rs
@@ -657,15 +657,18 @@ impl AccountSnapshotGenerator {
     ) -> StdResult<GetRewardsResp> {
         let querier = ElysQuerier::new(&deps.querier);
 
-        let rewards_response = querier.get_all_program_rewards(address.to_string())?;
+        // Elys Eden and Eden Boost Program rewards
+        let estaking_rewards = querier
+            .get_estaking_rewards(address.clone())
+            .unwrap_or_default();
+        // All pool rewards including USDC program rewards
+        let masterchef_rewards = querier.get_masterchef_pending_rewards(address.to_string())?;
 
         // Concatenate all staking reward vectors into one
-        let all_staking_rewards: Vec<&Coin> = rewards_response
-            .usdc_staking_rewards
+        let all_staking_rewards: Vec<&Coin> = estaking_rewards
+            .total
             .iter()
-            .chain(&rewards_response.elys_staking_rewards)
-            .chain(&rewards_response.eden_staking_rewards)
-            .chain(&rewards_response.edenb_staking_rewards)
+            .chain(&masterchef_rewards.total_rewards)
             .collect();
 
         // Accumulate amounts for each denomination

--- a/contracts/account-history-contract/src/types/account_snapshot_generator.rs
+++ b/contracts/account-history-contract/src/types/account_snapshot_generator.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     Coin, DecCoin, Decimal, Decimal256, Deps, Env, QuerierWrapper, StdError, StdResult, Uint128,
-    Uint256,
 };
 use cw_utils::Expiration;
 use elys_bindings::{
@@ -11,9 +10,9 @@ use elys_bindings::{
         msg::query_resp::{GetRewardsResp, StakeAssetBalanceBreakdown, StakedAssetsResponse},
         types::{
             earn_program::{EdenEarnProgram, ElysEarnProgram, UsdcEarnProgram},
-            AccountSnapshot, Coin256, Coin256Value, CoinValue, ElysDenom, LiquidAsset, Metadata,
-            PerpetualAsset, PerpetualAssets, PoolBalances, PortfolioBalanceSnapshot, Reward,
-            StakedAssets, TotalBalance,
+            AccountSnapshot, CoinValue, ElysDenom, LiquidAsset, Metadata, PerpetualAsset,
+            PerpetualAssets, PoolBalances, PortfolioBalanceSnapshot, Reward, StakedAssets,
+            TotalBalance,
         },
     },
     query_resp::{
@@ -145,7 +144,9 @@ impl AccountSnapshotGenerator {
         let all_rewards = querier
             .get_masterchef_pending_rewards(address.clone())
             .unwrap_or_default();
-        let coin_values_rewards = all_rewards.rewards_to_coins(&querier).unwrap_or_default();
+        let coin_values_rewards = all_rewards
+            .rewards_to_coin_values(&querier)
+            .unwrap_or_default();
 
         let mut total = Decimal::zero();
         let mut breakdown: HashMap<String, CoinValue> = HashMap::new();

--- a/contracts/account-history-contract/src/types/account_snapshot_generator.rs
+++ b/contracts/account-history-contract/src/types/account_snapshot_generator.rs
@@ -655,34 +655,35 @@ impl AccountSnapshotGenerator {
         address: &String,
     ) -> StdResult<GetRewardsResp> {
         let querier = ElysQuerier::new(&deps.querier);
-        // TODO: Vec<Coin>
+
         let rewards_response = querier.get_all_program_rewards(address.to_string())?;
 
         // Concatenate all staking reward vectors into one
-        // TODO: Vec<Coin>
-        let all_staking_rewards: Vec<Coin256> = rewards_response
+        let all_staking_rewards: Vec<&Coin> = rewards_response
             .usdc_staking_rewards
             .iter()
             .chain(&rewards_response.elys_staking_rewards)
             .chain(&rewards_response.eden_staking_rewards)
             .chain(&rewards_response.edenb_staking_rewards)
-            .map(|v| Coin256::from(v.clone()))
             .collect();
 
         // Accumulate amounts for each denomination
-        // TODO: use U128 instead of Decimal
-        let mut denom_amounts: HashMap<String, Uint256> = HashMap::new();
-
+        let mut denom_amounts: HashMap<String, Uint128> = HashMap::new();
         all_staking_rewards.iter().for_each(|coin| {
-            denom_amounts.insert(coin.denom.clone(), Uint256::zero());
+            denom_amounts
+                .entry(coin.denom.clone())
+                .and_modify(|amount| {
+                    *amount += coin.amount;
+                })
+                .or_insert(coin.amount);
         });
 
-        // Convert accumulated amounts to Coin256Value instances
-        let mut reward_map: HashMap<String, Coin256Value> = HashMap::new();
+        // Convert accumulated amounts to CoinValue instances
+        let mut reward_map: HashMap<String, CoinValue> = HashMap::new();
         for (denom, amount) in denom_amounts {
             let dec_coin_value = if denom != ElysDenom::EdenBoost.as_str().to_string() {
-                Coin256Value::from_coin256(
-                    &Coin256 {
+                CoinValue::from_coin(
+                    &Coin {
                         denom: denom.clone(),
                         amount,
                     },
@@ -690,22 +691,22 @@ impl AccountSnapshotGenerator {
                 )
                 .unwrap_or_default()
             } else {
-                Coin256Value::new(
+                CoinValue::new(
                     denom.clone(),
-                    Decimal256::new(amount),
+                    Decimal::new(amount),
                     Decimal::zero(),
-                    Decimal256::zero(),
+                    Decimal::zero(),
                 )
             };
 
             reward_map.insert(denom, dec_coin_value);
         }
 
-        let total_usd: Decimal256 = reward_map.values().map(|v| v.amount_usd).sum();
+        let total_usd: Decimal = reward_map.values().map(|v| v.amount_usd).sum();
 
         // Calculate other_usd as the sum of all amount_usd values in reward_map
         // excluding USDC, Eden, and EdenBoost
-        let mut other_usd: Decimal256 = Decimal256::zero();
+        let mut other_usd: Decimal = Decimal::zero();
         for (denom, value) in &reward_map {
             if denom != &self.metadata.usdc_denom
                 && denom != &ElysDenom::Eden.as_str().to_string()
@@ -733,8 +734,7 @@ impl AccountSnapshotGenerator {
         };
 
         // Construct rewards_vec as the values of all rewards_map entries
-        // TODO: use CoinValue
-        let rewards_vec: Vec<Coin256Value> = reward_map.into_iter().map(|(_, v)| v).collect();
+        let rewards_vec: Vec<CoinValue> = reward_map.into_iter().map(|(_, v)| v).collect();
 
         let resp = GetRewardsResp {
             rewards_map: reward,

--- a/contracts/account-history-contract/src/types/account_snapshot_generator.rs
+++ b/contracts/account-history-contract/src/types/account_snapshot_generator.rs
@@ -682,23 +682,14 @@ impl AccountSnapshotGenerator {
         // Convert accumulated amounts to CoinValue instances
         let mut reward_map: HashMap<String, CoinValue> = HashMap::new();
         for (denom, amount) in denom_amounts {
-            let dec_coin_value = if denom != ElysDenom::EdenBoost.as_str().to_string() {
-                CoinValue::from_coin(
-                    &Coin {
-                        denom: denom.clone(),
-                        amount,
-                    },
-                    &querier,
-                )
-                .unwrap_or_default()
-            } else {
-                CoinValue::new(
-                    denom.clone(),
-                    Decimal::new(amount),
-                    Decimal::zero(),
-                    Decimal::zero(),
-                )
-            };
+            let dec_coin_value = CoinValue::from_coin(
+                &Coin {
+                    denom: denom.clone(),
+                    amount,
+                },
+                &querier,
+            )
+            .unwrap_or_default();
 
             reward_map.insert(denom, dec_coin_value);
         }

--- a/contracts/trade-shield-contract/src/tests/claim_rewards_request/claim_rewards_request.rs
+++ b/contracts/trade-shield-contract/src/tests/claim_rewards_request/claim_rewards_request.rs
@@ -8,7 +8,6 @@ use crate::entry_point::{execute, query};
 use anyhow::{bail, Result as AnyResult};
 use cosmwasm_std::coin;
 use cosmwasm_std::Coin;
-use cosmwasm_std::Decimal256;
 use cosmwasm_std::StdError;
 use cosmwasm_std::Uint128;
 use cosmwasm_std::{to_json_binary, Addr, Empty};
@@ -153,24 +152,7 @@ impl Module for ElysModuleWrapper {
                     .iter_mut()
                     .position(|reward| reward.0 == validator_address)
                 {
-                    let reward_found: Vec<Coin> = rewards[index]
-                        .1
-                        .iter()
-                        .map(|reward| {
-                            coin(
-                                reward.amount.u128()
-                                    / 10u128.pow(
-                                        Decimal256::DECIMAL_PLACES
-                                            - DENOM_INFO
-                                                .iter()
-                                                .find(|denom_info| denom_info.0 == reward.denom)
-                                                .unwrap()
-                                                .1,
-                                    ),
-                                reward.denom.as_str(),
-                            )
-                        })
-                        .collect();
+                    let reward_found: Vec<Coin> = rewards[index].1.clone();
                     rewards.remove(index);
                     reward_found
                 } else {


### PR DESCRIPTION
# Description

- Rewards conversion from Coin to Coin256 was wrong, this pull request addresses the conversion to  already existing`CoinValue` and tries to fix the cascading issues.
- All rewards calculation was accounting only for the simple staking programs.
- Elys program query was broken when validator did not have ID.