### PR TITLE
fix: Earn query

### DIFF
--- a/bindings/src/account_history/msg/query.rs
+++ b/bindings/src/account_history/msg/query.rs
@@ -35,7 +35,7 @@ pub enum QueryMsg {
     #[returns(GetLiquidAssetsResp)]
     GetLiquidAssets { user_address: String },
     #[returns(StakedAssetsResponse)]
-    GetStakedAssets { user_address: String },
+    GetStakedAssets { user_address: Option<String> },
     #[returns(QueryUserPoolResponse)]
     GetPoolBalances { user_address: String },
     #[returns(GetRewardsResp)]

--- a/bindings/src/account_history/types/earn_program/elys_earn.rs
+++ b/bindings/src/account_history/types/earn_program/elys_earn.rs
@@ -34,7 +34,7 @@ pub struct ElysEarnProgram {
 impl Default for ElysEarnProgram {
     fn default() -> Self {
         Self {
-            bonding_period: 0,
+            bonding_period: 14,
             apr: AprElys::default(),
             available: None,
             staked: None,

--- a/contracts/account-history-contract/src/action/query/get_eden_earn_program_details.rs
+++ b/contracts/account-history-contract/src/action/query/get_eden_earn_program_details.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::msg::query_resp::earn::GetEdenEarnProgramResp;
-use cosmwasm_std::{Decimal, Deps, StdResult};
+use cosmwasm_std::{Decimal, Deps};
 use elys_bindings::account_history::types::earn_program::EdenEarnProgram;
 use elys_bindings::account_history::types::{AprElys, ElysDenom};
 use elys_bindings::query_resp::Validator;
@@ -24,50 +24,48 @@ pub fn get_eden_earn_program_details(
 
     let querier = ElysQuerier::new(&deps.querier);
 
-    let data = address.map_or(
-        Ok(EdenEarnProgram::default()),
-        |addr| -> StdResult<EdenEarnProgram> {
-            let all_rewards = querier
-                .get_estaking_rewards(addr.clone())
-                .unwrap_or_default();
-            let program_rewards = all_rewards
-                .get_validator_rewards(Validator::Eden)
-                .to_coin_values(&querier)
-                .unwrap_or_default()
-                .into_iter()
-                .map(|coin| coin.1)
-                .collect();
+    let mut data = EdenEarnProgram::default();
 
-            let mut available = querier.get_balance(addr.clone(), asset.clone())?;
-            let staked = querier.get_staked_balance(addr.clone(), asset.clone())?;
-            let vesting_info = querier.get_vesting_info(addr)?;
+    data.bonding_period = bonding_period;
+    data.apr = AprElys {
+        uusdc: usdc_apr.apr,
+        ueden: eden_apr.apr,
+        uedenb: edenb_apr.apr,
+    };
 
-            // have value in usd
-            let mut available_in_usd = uelys_price_in_uusdc
-                .checked_mul(
-                    Decimal::from_atomics(available.amount, 0).map_or(Decimal::zero(), |res| res),
-                )
-                .unwrap_or_default();
-            available_in_usd = available_in_usd
-                .checked_mul(uusdc_usd_price)
-                .unwrap_or_default();
-            available.usd_amount = available_in_usd;
+    if let Some(addr) = address {
+        let all_rewards = querier
+            .get_estaking_rewards(addr.clone())
+            .unwrap_or_default();
+        let program_rewards = all_rewards
+            .get_validator_rewards(Validator::Eden)
+            .to_coin_values(&querier)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|coin| coin.1)
+            .collect();
 
-            Ok(EdenEarnProgram {
-                bonding_period,
-                apr: AprElys {
-                    uusdc: usdc_apr.apr,
-                    ueden: eden_apr.apr,
-                    uedenb: edenb_apr.apr,
-                },
-                available: Some(available),
-                staked: Some(staked),
-                rewards: Some(program_rewards),
-                vesting: vesting_info.vesting,
-                vesting_details: vesting_info.vesting_details,
-            })
-        },
-    )?;
+        let mut available = querier.get_balance(addr.clone(), asset.clone())?;
+        let staked = querier.get_staked_balance(addr.clone(), asset.clone())?;
+        let vesting_info = querier.get_vesting_info(addr)?;
+
+        // have value in usd
+        let mut available_in_usd = uelys_price_in_uusdc
+            .checked_mul(
+                Decimal::from_atomics(available.amount, 0).map_or(Decimal::zero(), |res| res),
+            )
+            .unwrap_or_default();
+        available_in_usd = available_in_usd
+            .checked_mul(uusdc_usd_price)
+            .unwrap_or_default();
+        available.usd_amount = available_in_usd;
+
+        data.available = Some(available);
+        data.staked = Some(staked);
+        data.rewards = Some(program_rewards);
+        data.vesting = vesting_info.vesting;
+        data.vesting_details = vesting_info.vesting_details;
+    }
 
     Ok(GetEdenEarnProgramResp { data })
 }

--- a/contracts/account-history-contract/src/action/query/get_elys_earn_program_details.rs
+++ b/contracts/account-history-contract/src/action/query/get_elys_earn_program_details.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::msg::query_resp::earn::GetElysEarnProgramResp;
-use cosmwasm_std::{Decimal, Deps, StdResult};
+use cosmwasm_std::{Decimal, Deps};
 use elys_bindings::{
     account_history::types::{earn_program::ElysEarnProgram, AprElys, ElysDenom},
     query_resp::QueryAprResponse,
@@ -25,50 +25,48 @@ pub fn get_elys_earn_program_details(
 
     let querier = ElysQuerier::new(&deps.querier);
 
-    let data = address.map_or(
-        Ok(ElysEarnProgram::default()),
-        |addr| -> StdResult<ElysEarnProgram> {
-            let all_rewards = querier
-                .get_estaking_rewards(addr.clone())
-                .unwrap_or_default();
-            let program_rewards = all_rewards
-                .get_elys_validators()
-                .to_coin_values(&querier)
-                .unwrap_or_default()
-                .into_iter()
-                .map(|coin| coin.1)
-                .collect();
+    let mut data = ElysEarnProgram::default();
 
-            let mut available = querier.get_balance(addr.clone(), asset.clone())?;
-            let staked = querier.get_staked_balance(addr.clone(), asset)?;
+    data.bonding_period = bonding_period;
+    data.apr = AprElys {
+        uusdc: usdc_apr.apr,
+        ueden: eden_apr.apr,
+        uedenb: edenb_apr.apr,
+    };
 
-            let staked_positions = querier.get_staked_positions(addr.clone())?;
-            let unstaked_positions = querier.get_unstaked_positions(addr)?;
+    if let Some(addr) = address {
+        let all_rewards = querier
+            .get_estaking_rewards(addr.clone())
+            .unwrap_or_default();
+        let program_rewards = all_rewards
+            .get_elys_validators()
+            .to_coin_values(&querier)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|coin| coin.1)
+            .collect();
 
-            // have value in usd
-            let mut available_in_usd = uelys_price_in_uusdc
-                .checked_mul(Decimal::from_atomics(available.amount, 0).unwrap_or_default())
-                .unwrap_or_default();
-            available_in_usd = available_in_usd
-                .checked_mul(uusdc_usd_price)
-                .unwrap_or_default();
-            available.usd_amount = available_in_usd;
+        let mut available = querier.get_balance(addr.clone(), asset.clone())?;
+        let staked = querier.get_staked_balance(addr.clone(), asset)?;
 
-            Ok(ElysEarnProgram {
-                bonding_period,
-                apr: AprElys {
-                    uusdc: usdc_apr.apr,
-                    ueden: eden_apr.apr,
-                    uedenb: edenb_apr.apr,
-                },
-                available: Some(available),
-                staked: Some(staked),
-                rewards: Some(program_rewards),
-                staked_positions: staked_positions.staked_position,
-                unstaked_positions: unstaked_positions.unstaked_position,
-            })
-        },
-    )?;
+        let staked_positions = querier.get_staked_positions(addr.clone())?;
+        let unstaked_positions = querier.get_unstaked_positions(addr)?;
+
+        // have value in usd
+        let mut available_in_usd = uelys_price_in_uusdc
+            .checked_mul(Decimal::from_atomics(available.amount, 0).unwrap_or_default())
+            .unwrap_or_default();
+        available_in_usd = available_in_usd
+            .checked_mul(uusdc_usd_price)
+            .unwrap_or_default();
+        available.usd_amount = available_in_usd;
+
+        data.available = Some(available);
+        data.staked = Some(staked);
+        data.rewards = Some(program_rewards);
+        data.staked_positions = staked_positions.staked_position;
+        data.unstaked_positions = unstaked_positions.unstaked_position;
+    }
 
     Ok(GetElysEarnProgramResp { data })
 }

--- a/contracts/account-history-contract/src/action/query/get_staked_assets.rs
+++ b/contracts/account-history-contract/src/action/query/get_staked_assets.rs
@@ -5,12 +5,12 @@ use elys_bindings::ElysQuery;
 
 pub fn get_staked_assets(
     deps: Deps<ElysQuery>,
-    address: String,
+    address: Option<String>,
     _env: Env,
 ) -> StdResult<StakedAssetsResponse> {
     let generator = AccountSnapshotGenerator::new(&deps)?;
 
-    let staked_assets_response = generator.get_staked_assets(&deps, &address)?;
+    let staked_assets_response = generator.get_staked_assets(&deps, address)?;
 
     Ok(StakedAssetsResponse {
         total_staked_balance: DecCoin::new(

--- a/contracts/account-history-contract/src/action/query/get_usdc_earn_program_details.rs
+++ b/contracts/account-history-contract/src/action/query/get_usdc_earn_program_details.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::msg::query_resp::earn::GetUsdcEarnProgramResp;
-use cosmwasm_std::{Decimal, Deps, StdResult};
+use cosmwasm_std::{Decimal, Deps};
 use elys_bindings::{
     account_history::types::{earn_program::UsdcEarnProgram, AprUsdc, ElysDenom},
     ElysQuerier, ElysQuery,
@@ -25,43 +25,42 @@ pub fn get_usdc_earn_program_details(
         .get_masterchef_stable_stake_apr(ElysDenom::Usdc.as_str().to_string())
         .unwrap_or_default();
 
-    let data = address.map_or(
-        Ok(UsdcEarnProgram::default()),
-        |addr| -> StdResult<UsdcEarnProgram> {
-            let rewards = querier
-                .get_masterchef_pending_rewards(addr.clone())
-                .unwrap_or_default();
-            let coin_values_rewards = rewards.to_coin_values(&querier).unwrap_or_default();
-            let pool_rewards = coin_values_rewards.0[&pool_id].clone();
+    let mut data = UsdcEarnProgram::default();
 
-            let mut available = querier.get_balance(addr.clone(), usdc_denom)?;
-            available.usd_amount = available
-                .usd_amount
-                .checked_mul(uusdc_usd_price)
-                .unwrap_or_default();
+    data.bonding_period = bonding_period;
+    data.apr = AprUsdc {
+        uusdc: usdc_apr.apr,
+        ueden: eden_apr.apr,
+    };
 
-            let mut staked = querier.get_staked_balance(addr, usdc_base_denom)?;
+    if let Some(addr) = address {
+        let rewards = querier
+            .get_masterchef_pending_rewards(addr.clone())
+            .unwrap_or_default();
+        let coin_values_rewards = rewards.to_coin_values(&querier).unwrap_or_default();
+        let pool_rewards = coin_values_rewards.0[&pool_id].clone();
 
-            let mut borrowed = querier.get_borrowed_balance()?;
-            borrowed.usd_amount = borrowed
-                .usd_amount
-                .checked_mul(uusdc_usd_price)
-                .unwrap_or_default();
+        let mut available = querier.get_balance(addr.clone(), usdc_denom)?;
+        available.usd_amount = available
+            .usd_amount
+            .checked_mul(uusdc_usd_price)
+            .unwrap_or_default();
 
-            staked.lockups = None;
+        let mut staked = querier.get_staked_balance(addr, usdc_base_denom)?;
 
-            Ok(UsdcEarnProgram {
-                bonding_period,
-                apr: AprUsdc {
-                    uusdc: usdc_apr.apr,
-                    ueden: eden_apr.apr,
-                },
-                available: Some(available),
-                staked: Some(staked),
-                rewards: Some(pool_rewards),
-                borrowed: Some(borrowed),
-            })
-        },
-    )?;
+        let mut borrowed = querier.get_borrowed_balance()?;
+        borrowed.usd_amount = borrowed
+            .usd_amount
+            .checked_mul(uusdc_usd_price)
+            .unwrap_or_default();
+
+        staked.lockups = None;
+
+        data.available = Some(available);
+        data.staked = Some(staked);
+        data.rewards = Some(pool_rewards);
+        data.borrowed = Some(borrowed);
+    }
+
     Ok(GetUsdcEarnProgramResp { data })
 }

--- a/contracts/account-history-contract/src/tests/get_staked_assets.rs
+++ b/contracts/account-history-contract/src/tests/get_staked_assets.rs
@@ -638,7 +638,7 @@ fn get_staked_assets() {
         .query_wasm_smart(
             &addr,
             &QueryMsg::GetStakedAssets {
-                user_address: "user".to_string(),
+                user_address: Some("user".to_string()),
             },
         )
         .unwrap();

--- a/contracts/account-history-contract/src/types/account_snapshot_generator.rs
+++ b/contracts/account-history-contract/src/types/account_snapshot_generator.rs
@@ -83,7 +83,7 @@ impl AccountSnapshotGenerator {
         address: &String,
     ) -> StdResult<AccountSnapshot> {
         let liquid_assets_response = self.get_liquid_assets(&deps, querier, &address)?;
-        let staked_assets_response = self.get_staked_assets(&deps, &address)?;
+        let staked_assets_response = self.get_staked_assets(&deps, Some(address.clone()))?;
         let rewards_response = self.get_rewards(&deps, &address)?;
         let perpetual_response = self.get_perpetuals(&deps, &address)?;
         let pool_balances_response = self.get_pool_balances(&deps, &address)?;
@@ -409,7 +409,7 @@ impl AccountSnapshotGenerator {
     pub fn get_staked_assets(
         &self,
         deps: &Deps<ElysQuery>,
-        address: &String,
+        address: Option<String>,
     ) -> StdResult<StakedAssetsResponse> {
         let querier = ElysQuerier::new(&deps.querier);
 
@@ -421,7 +421,7 @@ impl AccountSnapshotGenerator {
 
         let usdc_details = get_usdc_earn_program_details(
             deps,
-            Some(address.to_owned()),
+            address.clone(),
             self.metadata.usdc_denom.to_owned(),
             self.metadata.usdc_base_denom.to_owned(),
             self.metadata.uusdc_usd_price,
@@ -443,7 +443,7 @@ impl AccountSnapshotGenerator {
         // elys program
         let elys_details = get_elys_earn_program_details(
             deps,
-            Some(address.to_owned()),
+            address.clone(),
             ElysDenom::Elys.as_str().to_string(),
             self.metadata.uusdc_usd_price,
             self.metadata.uelys_price_in_uusdc,
@@ -486,7 +486,7 @@ impl AccountSnapshotGenerator {
         // eden program
         let eden_details = get_eden_earn_program_details(
             deps,
-            Some(address.to_owned()),
+            address.clone(),
             ElysDenom::Eden.as_str().to_string(),
             self.metadata.uusdc_usd_price,
             self.metadata.uelys_price_in_uusdc,
@@ -517,7 +517,7 @@ impl AccountSnapshotGenerator {
 
         let edenb_details = get_eden_boost_earn_program_details(
             deps,
-            Some(address.to_owned()),
+            address,
             ElysDenom::EdenBoost.as_str().to_string(),
             QueryAprResponse {
                 apr: aprs.usdc_apr_edenb,

--- a/scripts/queries.sh
+++ b/scripts/queries.sh
@@ -126,6 +126,15 @@ function staked_assets() {
     }'
 }
 
+function staked_assets_no_user() {
+    printf "\n# Staked assets\n"
+    query_contract "$ah_contract_address" '{
+        "get_staked_assets": {
+        }
+    }'
+}
+
+
 # Get perpetual assets
 function perpetual_assets() {
     printf "\n# Perpertual assets\n"
@@ -605,6 +614,9 @@ case "$2" in
     ;;
 "staked_assets")
     staked_assets
+    ;;
+"staked_assets_no_user")
+    staked_assets_no_user
     ;;
 "perpetual_assets")
     perpetual_assets


### PR DESCRIPTION
### Now you can query the staked asset without providing an address

## Query

```sh
./scripts/queries.sh elys1g3qnq7apxv964cqj0hza0pnwsw3q920lcc5lyg staked_assets_no_user
```
or
```sh
elysd q --output json --node "tcp://localhost:26657" wasm contract-state smart "elys17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgs98tvuy" '{
        "get_staked_assets": {
        }
    }' | jq
```

## Response

```json
{
  "data": {
    "total_staked_balance": {
      "denom": "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65",
      "amount": "0"
    },
    "staked_assets": {
      "eden_boost_earn_program": {
        "bonding_period": 0,
        "apr": {
          "uusdc": "0",
          "ueden": "0"
        },
        "available": null,
        "staked": null,
        "rewards": null
      },
      "eden_earn_program": {
        "bonding_period": 0,
        "apr": {
          "uusdc": "0",
          "ueden": "0",
          "uedenb": "0"
        },
        "available": null,
        "staked": null,
        "rewards": null,
        "vesting": {
          "amount": "0",
          "usd_amount": "0"
        },
        "vesting_details": null
      },
      "elys_earn_program": {
        "bonding_period": 0,
        "apr": {
          "uusdc": "0",
          "ueden": "0",
          "uedenb": "0"
        },
        "available": null,
        "staked": null,
        "rewards": null,
        "staked_positions": null,
        "unstaked_positions": null
      },
      "usdc_earn_program": {
        "bonding_period": 0,
        "apr": {
          "uusdc": "0",
          "ueden": "0"
        },
        "available": null,
        "staked": null,
        "rewards": null,
        "borrowed": null
      }
    },
    "total_balance": "0",
    "balance_break_down": {
      "staked": "0",
      "unstaking": "0",
      "vesting": "0"
    }
  }
}
```