### PR TITLE
Fix: leveragelp get_status query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "base16ct"
@@ -121,9 +121,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "num-traits",
 ]
@@ -579,9 +579,9 @@ checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]

--- a/bindings-test/src/multitest.rs
+++ b/bindings-test/src/multitest.rs
@@ -23,7 +23,7 @@ use elys_bindings::{
         AmmSwapEstimationByDenomResponse, AmmSwapEstimationResponse, AuthAddressesResponse,
         BalanceBorrowed, Commitments, Entry, EstakingRewardsResponse,
         LeveragelpIsWhitelistedResponse, LeveragelpParams, LeveragelpParamsResponse,
-        LeveragelpStatusReponse, LeveragelpWhitelistResponse, MasterchefUserPendingRewardResponse,
+        LeveragelpStatusResponse, LeveragelpWhitelistResponse, MasterchefUserPendingRewardResponse,
         OracleAssetInfoResponse, PerpetualGetPositionsForAddressResponse, PerpetualMtpResponse,
         PerpetualOpenEstimationRawResponse, PerpetualQueryPositionsResponse, PoolApr,
         QueryAprResponse, QueryAprsResponse, QueryGetEntryAllResponse, QueryGetEntryResponse,
@@ -134,7 +134,7 @@ impl Module for ElysModule {
             }
 
             ElysQuery::LeveragelpGetStatus { .. } => {
-                let resp = LeveragelpStatusReponse {
+                let resp = LeveragelpStatusResponse {
                     open_position_count: 10,
                     lifetime_position_count: 100,
                 };

--- a/bindings/src/querier.rs
+++ b/bindings/src/querier.rs
@@ -881,7 +881,7 @@ impl<'a> ElysQuerier<'a> {
             pagination: raw_resp.pagination,
         })
     }
-    pub fn leveragelp_get_status(&self) -> StdResult<LeveragelpStatusReponse> {
+    pub fn leveragelp_get_status(&self) -> StdResult<LeveragelpStatusResponse> {
         let req = QueryRequest::Custom(ElysQuery::leveragelp_get_status());
         self.querier.query(&req)
     }

--- a/bindings/src/querier.rs
+++ b/bindings/src/querier.rs
@@ -883,7 +883,12 @@ impl<'a> ElysQuerier<'a> {
     }
     pub fn leveragelp_get_status(&self) -> StdResult<LeveragelpStatusResponse> {
         let req = QueryRequest::Custom(ElysQuery::leveragelp_get_status());
-        self.querier.query(&req)
+        let raw_resp: LeveragelpStatusResponseRaw = self.querier.query(&req)?;
+        let resp = LeveragelpStatusResponse {
+            open_position_count: raw_resp.open_position_count.unwrap_or(0),
+            lifetime_position_count: raw_resp.lifetime_position_count.unwrap_or(0),
+        };
+        Ok(resp)
     }
     pub fn leveragelp_query_positions_for_address(
         &self,

--- a/bindings/src/query.rs
+++ b/bindings/src/query.rs
@@ -126,7 +126,7 @@ pub enum ElysQuery {
         amm_pool_id: u64,
         pagination: Option<PageRequest>,
     },
-    #[returns(LeveragelpStatusReponse)]
+    #[returns(LeveragelpStatusResponse)]
     LeveragelpGetStatus {},
     #[returns(LeveragelpPositionsResponse)]
     LeveragelpQueryPositionsForAddress {

--- a/bindings/src/query_resp.rs
+++ b/bindings/src/query_resp.rs
@@ -624,6 +624,12 @@ pub struct LeveragelpStatusResponse {
 }
 
 #[cw_serde]
+pub struct LeveragelpStatusResponseRaw {
+    pub open_position_count: Option<u64>,
+    pub lifetime_position_count: Option<u64>,
+}
+
+#[cw_serde]
 pub struct LeveragelpWhitelistResponseRaw {
     pub whitelist: Option<Vec<String>>,
     pub pagination: Option<PageResponse>,

--- a/bindings/src/query_resp.rs
+++ b/bindings/src/query_resp.rs
@@ -618,7 +618,7 @@ pub struct LeveragelpPositionsResponse {
 }
 
 #[cw_serde]
-pub struct LeveragelpStatusReponse {
+pub struct LeveragelpStatusResponse {
     pub open_position_count: u64,
     pub lifetime_position_count: u64,
 }

--- a/bindings/src/trade_shield/msg/query_msg.rs
+++ b/bindings/src/trade_shield/msg/query_msg.rs
@@ -70,7 +70,7 @@ pub enum QueryMsg {
         amm_pool_id: u64,
         pagination: Option<PageRequest>,
     },
-    #[returns(LeveragelpStatusReponse)]
+    #[returns(LeveragelpStatusResponse)]
     LeveragelpGetStatus {},
     #[returns(LeveragelpPositionsResponse)]
     LeveragelpQueryPositionsForAddress {


### PR DESCRIPTION
Error:

```
ay@Amits-Air elys % ./build/elysd query wasm contract-state smart elys10yuktlug2v57v3nyutwv78wxnv26z4ad0wnhz63s30dq287302ysdpkmjd '{"leveragelp_get_status": {}}' --node=https://rpc.testnet.elys.network:443
Error: rpc error: code = Unknown desc = Error parsing into type elys_bindings::query_resp::LeveragelpStatusReponse: missing field `open_position_count`: query wasm
```

Fixed:

```
ay@Amits-MacBook-Air artifacts % elysd query wasm contract-state smart elys1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqau4f4q '{"leveragelp_get_status": {}}'
data:
  lifetime_position_count: 3
  open_position_count: 0

```