### PR TITLE
remove unexistant query

### DIFF
--- a/bindings-test/src/multitest.rs
+++ b/bindings-test/src/multitest.rs
@@ -564,13 +564,6 @@ impl Module for ElysModule {
                 };
                 Ok(to_json_binary(&resp)?)
             }
-            ElysQuery::CommitmentRewardsSubBucketBalanceOfDenom { .. } => {
-                let resp = BalanceAvailable {
-                    amount: Uint128::new(100),
-                    usd_amount: Decimal::from_atomics(Uint128::new(100), 0).unwrap(),
-                };
-                Ok(to_json_binary(&resp)?)
-            }
             ElysQuery::CommitmentStakedBalanceOfDenom { .. } => {
                 // This is returning the same staked balance for each staking program (Usdc program, eden program, elys program, etc.).
                 let resp = BalanceAvailable {

--- a/bindings/src/account_history/msg/query.rs
+++ b/bindings/src/account_history/msg/query.rs
@@ -108,14 +108,6 @@ pub enum QueryMsg {
     CommitmentUnStakedPositions { delegator_address: String },
 
     #[cfg(feature = "debug")]
-    #[returns(BalanceAvailable)]
-    CommitmentRewardsSubBucketBalanceOfDenom {
-        address: String,
-        denom: String,
-        program: i32,
-    },
-
-    #[cfg(feature = "debug")]
     #[returns(StakedAvailable)]
     CommitmentStakedBalanceOfDenom { address: String, denom: String },
 

--- a/bindings/src/msg.rs
+++ b/bindings/src/msg.rs
@@ -10,21 +10,7 @@ use crate::{
 
 #[cw_serde]
 pub enum ElysMsg {
-    PerpetualOpen {
-        creator: String,
-        position: i32,
-        collateral: Coin,
-        trading_asset: String,
-        leverage: SignedDecimal,
-        take_profit_price: SignedDecimal256,
-        owner: String,
-    },
-    PerpetualClose {
-        creator: String,
-        id: u64,
-        amount: Int128,
-        owner: String,
-    },
+    // Amm
     AmmSwapExactAmountIn {
         sender: String,
         routes: Vec<SwapAmountInRoute>,
@@ -43,43 +29,6 @@ pub enum ElysMsg {
         discount: Decimal,
         recipient: String,
     },
-    CommitmentStake {
-        creator: String,
-        amount: Int128,
-        asset: String,
-        validator_address: Option<String>,
-    },
-    CommitmentUnstake {
-        creator: String,
-        amount: Int128,
-        asset: String,
-        validator_address: Option<String>,
-    },
-    IncentiveBeginRedelegate {
-        delegator_address: String,
-        validator_src_address: String,
-        validator_dst_address: String,
-        amount: Coin,
-    },
-    IncentiveCancelUnbondingDelegation {
-        delegator_address: String,
-        validator_address: String,
-        amount: Coin,
-        creation_height: i64,
-    },
-    CommitmentVest {
-        creator: String,
-        amount: Int128,
-        denom: String,
-    },
-    CommitmentCancelVest {
-        creator: String,
-        amount: Int128,
-        denom: String,
-    },
-    CommitmentClaimVesting {
-        sender: String,
-    },
     AmmJoinPool {
         sender: String,
         pool_id: u64,
@@ -95,6 +44,63 @@ pub enum ElysMsg {
         token_out_denom: String,
     },
 
+    // Commitment
+    CommitmentStake {
+        creator: String,
+        amount: Int128,
+        asset: String,
+        validator_address: Option<String>,
+    },
+    CommitmentUnstake {
+        creator: String,
+        amount: Int128,
+        asset: String,
+        validator_address: Option<String>,
+    },
+    CommitmentVest {
+        creator: String,
+        amount: Int128,
+        denom: String,
+    },
+    CommitmentCancelVest {
+        creator: String,
+        amount: Int128,
+        denom: String,
+    },
+    CommitmentClaimVesting {
+        sender: String,
+    },
+
+    // Incentive
+    IncentiveBeginRedelegate {
+        delegator_address: String,
+        validator_src_address: String,
+        validator_dst_address: String,
+        amount: Coin,
+    },
+    IncentiveCancelUnbondingDelegation {
+        delegator_address: String,
+        validator_address: String,
+        amount: Coin,
+        creation_height: i64,
+    },
+
+    // Masterchef
+    MasterchefClaimRewards {
+        sender: String,
+        pool_ids: Vec<u64>,
+    },
+
+    // Estaking
+    EstakingWithdrawElysStakingRewards {
+        delegator_address: String,
+    },
+
+    EstakingWithdrawReward {
+        validator_address: String,
+        delegator_address: String,
+    },
+    // Leveragelp
     LeveragelpOpen {
         creator: String,
         collateral_asset: String,
@@ -109,18 +115,21 @@ pub enum ElysMsg {
         lp_amount: Int128,
     },
 
-    EstakingWithdrawElysStakingRewards {
-        delegator_address: String,
+    // Perpetual
+    PerpetualOpen {
+        creator: String,
+        position: i32,
+        collateral: Coin,
+        trading_asset: String,
+        leverage: SignedDecimal,
+        take_profit_price: SignedDecimal256,
+        owner: String,
     },
-
-    MasterchefClaimRewards {
-        sender: String,
-        pool_ids: Vec<u64>,
-    },
-
-    EstakingWithdrawReward {
-        validator_address: String,
-        delegator_address: String,
+    PerpetualClose {
+        creator: String,
+        id: u64,
+        amount: Int128,
+        owner: String,
     },
 }
 

--- a/bindings/src/querier.rs
+++ b/bindings/src/querier.rs
@@ -311,22 +311,6 @@ impl<'a> ElysQuerier<'a> {
         Ok(resp)
     }
 
-    pub fn get_sub_bucket_rewards_balance(
-        &self,
-        address: String,
-        denom: String,
-        program: i32,
-    ) -> StdResult<BalanceAvailable> {
-        let sub_bucket_reward_query = ElysQuery::CommitmentRewardsSubBucketBalanceOfDenom {
-            address,
-            denom,
-            program,
-        };
-        let request: QueryRequest<ElysQuery> = QueryRequest::Custom(sub_bucket_reward_query);
-        let resp: BalanceAvailable = self.querier.query(&request)?;
-        Ok(resp)
-    }
-
     pub fn get_oracle_price(
         &self,
         asset: String,

--- a/bindings/src/query.rs
+++ b/bindings/src/query.rs
@@ -32,77 +32,8 @@ pub enum ElysQuery {
     AmmPool { pool_id: u64 },
     #[returns(AmmGetPoolsResponse)]
     AmmPoolAll { pagination: Option<PageRequest> },
-    // Define OracleQuery
-    #[returns(OracleAllPriceResponse)]
-    OraclePriceAll { pagination: PageRequest },
-    #[returns(OracleAssetInfoResponse)]
-    OracleAssetInfo { denom: String },
-    #[returns(QueryGetPriceResponse)]
-    OraclePrice {
-        asset: String,
-        source: String,
-        timestamp: u64,
-    },
-    // Define PerpetualQuery
-    #[returns(PerpetualQueryPositionsResponse)]
-    PerpetualQueryPositions { pagination: PageRequest },
-    #[returns(PerpetualMtpResponse)]
-    PerpetualMtp { address: String, id: u64 },
-    #[returns(PerpetualOpenEstimationResponse)]
-    PerpetualOpenEstimation {
-        position: i32,
-        leverage: SignedDecimal,
-        trading_asset: String,
-        collateral: Coin,
-        take_profit_price: SignedDecimal256,
-        discount: Decimal,
-    },
-    #[returns(PerpetualGetPositionsForAddressResponse)]
-    PerpetualGetPositionsForAddress {
-        address: String,
-        pagination: Option<PageRequest>,
-    },
-    // Define AuthQuery
-    #[returns(AuthAddressesResponse)]
-    AuthAddresses { pagination: Option<PageRequest> },
-    #[returns(QueryGetEntryResponse)]
-    AssetProfileEntry { base_denom: String },
-    #[returns(QueryGetEntryAllResponse)]
-    AssetProfileEntryAll { pagination: Option<PageRequest> },
-    #[returns(QueryAprResponse)]
-    IncentiveApr { withdraw_type: i32, denom: String },
-    #[returns(QueryAprsResponse)]
-    IncentiveAprs {},
-    #[returns(BalanceAvailable)]
-    CommitmentRewardsSubBucketBalanceOfDenom {
-        address: String,
-        denom: String,
-        program: i32,
-    },
-    #[returns(BalanceAvailable)]
-    CommitmentStakedBalanceOfDenom { address: String, denom: String },
     #[returns(Decimal)]
     AmmPriceByDenom { token_in: Coin, discount: Decimal },
-    #[returns(QueryStakedPositionResponse)]
-    CommitmentStakedPositions { delegator_address: String },
-    #[returns(QueryUnstakedPositionResponse)]
-    CommitmentUnStakedPositions { delegator_address: String },
-    #[returns(BalanceBorrowed)]
-    StableStakeBalanceOfBorrow {},
-    #[returns(StableStakeParamsResp)]
-    StableStakeParams {},
-    #[returns(QueryDelegatorDelegationsResponse)]
-    CommitmentDelegations { delegator_address: String },
-    #[returns(QueryDelegatorUnbondingDelegationsResponse)]
-    CommitmentUnbondingDelegations { delegator_address: String },
-    #[returns(QueryDelegatorValidatorsResponse)]
-    CommitmentAllValidators { delegator_address: String },
-    #[returns(QueryDelegatorValidatorsResponse)]
-    CommitmentDelegatorValidators { delegator_address: String },
-    #[returns(QueryShowCommitmentsResponse)]
-    CommitmentShowCommitments { creator: String },
-    #[returns(QueryVestingInfoResponse)]
-    CommitmentVestingInfo { address: String },
     #[returns(QueryEarnPoolResponse)]
     AmmEarnMiningPoolAll {
         pool_ids: Option<Vec<u64>>,
@@ -117,6 +48,58 @@ pub enum ElysQuery {
         share_amount_in: Uint128,
         token_out_denom: String,
     },
+
+    // Define AssetProfil
+    #[returns(QueryGetEntryResponse)]
+    AssetProfileEntry { base_denom: String },
+    #[returns(QueryGetEntryAllResponse)]
+    AssetProfileEntryAll { pagination: Option<PageRequest> },
+
+    // Define AuthQuery
+    #[returns(AuthAddressesResponse)]
+    AuthAddresses { pagination: Option<PageRequest> },
+
+    // Define Commitment
+    #[returns(BalanceAvailable)]
+    CommitmentStakedBalanceOfDenom { address: String, denom: String },
+    #[returns(QueryStakedPositionResponse)]
+    CommitmentStakedPositions { delegator_address: String },
+    #[returns(QueryUnstakedPositionResponse)]
+    CommitmentUnStakedPositions { delegator_address: String },
+    #[returns(QueryDelegatorDelegationsResponse)]
+    CommitmentDelegations { delegator_address: String },
+    #[returns(QueryDelegatorUnbondingDelegationsResponse)]
+    CommitmentUnbondingDelegations { delegator_address: String },
+    #[returns(QueryDelegatorValidatorsResponse)]
+    CommitmentAllValidators { delegator_address: String },
+    #[returns(QueryDelegatorValidatorsResponse)]
+    CommitmentDelegatorValidators { delegator_address: String },
+    #[returns(QueryShowCommitmentsResponse)]
+    CommitmentShowCommitments { creator: String },
+    #[returns(QueryVestingInfoResponse)]
+    CommitmentVestingInfo { address: String },
+    #[returns(CommitmentNumberOfCommitmentsResponse)]
+    CommitmentNumberOfCommitments {},
+
+    // Define Incentive
+    #[returns(QueryAprResponse)]
+    IncentiveApr { withdraw_type: i32, denom: String },
+    #[returns(QueryAprsResponse)]
+    IncentiveAprs {},
+
+    // Define Masterchef
+    #[returns(MasterchefUserPendingRewardResponse)]
+    MasterchefUserPendingReward { user: String },
+    #[returns(QueryPoolAprsResponse)]
+    MasterchefPoolAprs { pool_ids: Vec<u64> },
+    #[returns(QueryStableStakeAprResponse)]
+    MasterchefStableStakeApr { denom: String },
+
+    // Define Estaking
+    #[returns(EstakingRewardsResponse)]
+    EstakingRewards { address: String },
+
+    // Define Leveragelp
     #[returns(LeveragelpParamsResponse)]
     LeveragelpParams {},
     #[returns(LeveragelpPositionsResponse)]
@@ -143,16 +126,44 @@ pub enum ElysQuery {
     LeveragelpPools { pagination: Option<PageRequest> },
     #[returns(LeveragelpPositionResponse)]
     LeveragelpPosition { address: String, id: u64 },
-    #[returns(MasterchefUserPendingRewardResponse)]
-    MasterchefUserPendingReward { user: String },
-    #[returns(EstakingRewardsResponse)]
-    EstakingRewards { address: String },
-    #[returns(QueryPoolAprsResponse)]
-    MasterchefPoolAprs { pool_ids: Vec<u64> },
-    #[returns(QueryStableStakeAprResponse)]
-    MasterchefStableStakeApr { denom: String },
-    #[returns(CommitmentNumberOfCommitmentsResponse)]
-    CommitmentNumberOfCommitments {},
+
+    // Define Perpetual
+    #[returns(PerpetualQueryPositionsResponse)]
+    PerpetualQueryPositions { pagination: PageRequest },
+    #[returns(PerpetualMtpResponse)]
+    PerpetualMtp { address: String, id: u64 },
+    #[returns(PerpetualOpenEstimationResponse)]
+    PerpetualOpenEstimation {
+        position: i32,
+        leverage: SignedDecimal,
+        trading_asset: String,
+        collateral: Coin,
+        take_profit_price: SignedDecimal256,
+        discount: Decimal,
+    },
+    #[returns(PerpetualGetPositionsForAddressResponse)]
+    PerpetualGetPositionsForAddress {
+        address: String,
+        pagination: Option<PageRequest>,
+    },
+
+    // Define Oracle
+    #[returns(OracleAllPriceResponse)]
+    OraclePriceAll { pagination: PageRequest },
+    #[returns(OracleAssetInfoResponse)]
+    OracleAssetInfo { denom: String },
+    #[returns(QueryGetPriceResponse)]
+    OraclePrice {
+        asset: String,
+        source: String,
+        timestamp: u64,
+    },
+
+    // Define Stablestake
+    #[returns(BalanceBorrowed)]
+    StableStakeBalanceOfBorrow {},
+    #[returns(StableStakeParamsResp)]
+    StableStakeParams {},
 }
 
 impl CustomQuery for ElysQuery {}
@@ -245,13 +256,6 @@ impl ElysQuery {
         Self::PerpetualGetPositionsForAddress {
             address,
             pagination,
-        }
-    }
-    pub fn get_sub_bucket_rewards_balance(address: String, denom: String, program: i32) -> Self {
-        ElysQuery::CommitmentRewardsSubBucketBalanceOfDenom {
-            address,
-            denom,
-            program,
         }
     }
     pub fn get_oracle_price(asset: String, source: String, timestamp: u64) -> Self {

--- a/contracts/account-history-contract/src/entry_point/query.rs
+++ b/contracts/account-history-contract/src/entry_point/query.rs
@@ -123,15 +123,6 @@ pub fn query(deps: Deps<ElysQuery>, env: Env, msg: QueryMsg) -> StdResult<Binary
             to_json_binary(&querier.get_unstaked_positions(delegator_address)?)
         }
         #[cfg(feature = "debug")]
-        CommitmentRewardsSubBucketBalanceOfDenom {
-            address,
-            denom,
-            program,
-        } => {
-            let querier = ElysQuerier::new(&deps.querier);
-            to_json_binary(&querier.get_sub_bucket_rewards_balance(address, denom, program)?)
-        }
-        #[cfg(feature = "debug")]
         CommitmentStakedBalanceOfDenom { address, denom } => {
             let querier = ElysQuerier::new(&deps.querier);
             to_json_binary(&querier.get_staked_balance(address, denom)?)

--- a/contracts/account-history-contract/src/tests/get_staked_assets.rs
+++ b/contracts/account-history-contract/src/tests/get_staked_assets.rs
@@ -192,64 +192,6 @@ impl Module for ElysModuleWrapper {
                 };
                 Ok(to_json_binary(&resp)?)
             }
-            ElysQuery::CommitmentRewardsSubBucketBalanceOfDenom { denom, program, .. } => {
-                let resp: BalanceAvailable = match (denom.as_str(), program) {
-                    ("ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65", 1) => {
-                        BalanceAvailable {
-                            amount: Uint128::zero(),
-                            usd_amount: Decimal::zero(),
-                        }
-                    }
-                    ("ueden", 1) => BalanceAvailable {
-                        amount: Uint128::new(349209420),
-                        usd_amount: Decimal::from_str("349209420").unwrap(),
-                    },
-                    ("ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65", 2) => {
-                        BalanceAvailable {
-                            amount: Uint128::zero(),
-                            usd_amount: Decimal::zero(),
-                        }
-                    }
-                    ("ueden", 2) => BalanceAvailable {
-                        amount: Uint128::new(9868),
-                        usd_amount: Decimal::from_str("9868").unwrap(),
-                    },
-                    ("uedenb", 2) => BalanceAvailable {
-                        amount: Uint128::new(654083056),
-                        usd_amount: Decimal::from_str("654083056").unwrap(),
-                    },
-                    ("ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65", 3) => {
-                        BalanceAvailable {
-                            amount: Uint128::new(1161),
-                            usd_amount: Decimal::from_str("1161").unwrap(),
-                        }
-                    }
-                    ("ueden", 3) => BalanceAvailable {
-                        amount: Uint128::new(2984882),
-                        usd_amount: Decimal::from_str("2984882").unwrap(),
-                    },
-                    ("uedenb", 3) => BalanceAvailable {
-                        amount: Uint128::new(10155052),
-                        usd_amount: Decimal::from_str("10155052").unwrap(),
-                    },
-                    ("ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65", 4) => {
-                        BalanceAvailable {
-                            amount: Uint128::zero(),
-                            usd_amount: Decimal::zero(),
-                        }
-                    }
-                    ("ueden", 4) => BalanceAvailable {
-                        amount: Uint128::zero(),
-                        usd_amount: Decimal::zero(),
-                    },
-                    ("uedenb", 4) => BalanceAvailable {
-                        amount: Uint128::zero(),
-                        usd_amount: Decimal::zero(),
-                    },
-                    _ => return Err(Error::new(StdError::not_found(denom))),
-                };
-                Ok(to_json_binary(&resp)?)
-            }
             ElysQuery::CommitmentStakedPositions { delegator_address } => {
                 let resp = match delegator_address.as_str() {
                     "user" => QueryStakedPositionResponse {


### PR DESCRIPTION
- Remove unexistant query in the Wasm bindings: `CommitmentRewardsSubBucketBalanceOfDenom`
- make the enum more readable