### PR TITLE
fix: 🐛 add error handling on leverage open

### DIFF
--- a/contracts/trade-shield-contract/src/action/execute/open_leveragelp_position_request.rs
+++ b/contracts/trade-shield-contract/src/action/execute/open_leveragelp_position_request.rs
@@ -14,6 +14,13 @@ pub fn open_leveragelp_position_request(
         return Err(StdError::generic_err("leverage endpoint are disable").into());
     }
 
+    if leverage <= SignedDecimal::one() {
+        return Err(StdError::generic_err("leverage must be greater than 1").into());
+    }
+    if collateral_amount <= Int128::zero() {
+        return Err(StdError::generic_err("collateral amount must be greater than 0").into());
+    }
+
     let msg: ElysMsg = ElysMsg::leveragelp_open_position(
         info.sender.to_string(),
         amm_pool_id,

--- a/contracts/trade-shield-contract/src/tests/leveragelp_open/invalid_collateral.rs
+++ b/contracts/trade-shield-contract/src/tests/leveragelp_open/invalid_collateral.rs
@@ -1,0 +1,57 @@
+use cosmwasm_std::{Int128, SignedDecimal, StdError};
+
+use super::*;
+
+#[test]
+fn invalid_leverage() {
+    let mut app = ElysApp::new();
+
+    let trade_shield_code = ContractWrapper::new(execute, instantiate, query);
+    let trade_shield_code_id = app.store_code(Box::new(trade_shield_code));
+    let trade_shield_init = InstantiateMockMsg {
+        account_history_address: None,
+        spot_orders: vec![],
+        perpetual_orders: vec![],
+    };
+
+    let addr = app
+        .instantiate_contract(
+            trade_shield_code_id,
+            Addr::unchecked("admin"),
+            &trade_shield_init,
+            &[],
+            "contract",
+            None,
+        )
+        .unwrap();
+
+    let invalid_message = ExecuteMsg::LeveragelpOpen {
+        amm_pool_id: 1,
+        collateral_asset: "uusdc".to_string(),
+        collateral_amount: Int128::zero(),
+        leverage: SignedDecimal::from_str("2.0").unwrap(),
+        stop_loss_price: SignedDecimal::zero(),
+    };
+
+    let valid_message = ExecuteMsg::LeveragelpOpen {
+        amm_pool_id: 1,
+        collateral_asset: "uusdc".to_string(),
+        collateral_amount: Int128::new(1000000),
+        leverage: SignedDecimal::from_str("2.0").unwrap(),
+        stop_loss_price: SignedDecimal::zero(),
+    };
+
+    let error = app
+        .execute_contract(Addr::unchecked("user"), addr.clone(), &invalid_message, &[])
+        .unwrap_err();
+
+    assert_eq!(
+        ContractError::StdError(StdError::generic_err(
+            "collateral amount must be greater than 0"
+        )),
+        error.downcast().unwrap()
+    );
+
+    app.execute_contract(Addr::unchecked("user"), addr, &valid_message, &[])
+        .unwrap();
+}

--- a/contracts/trade-shield-contract/src/tests/leveragelp_open/invalid_leverage.rs
+++ b/contracts/trade-shield-contract/src/tests/leveragelp_open/invalid_leverage.rs
@@ -1,0 +1,55 @@
+use cosmwasm_std::{Int128, SignedDecimal, StdError};
+
+use super::*;
+
+#[test]
+fn invalid_leverage() {
+    let mut app = ElysApp::new();
+
+    let trade_shield_code = ContractWrapper::new(execute, instantiate, query);
+    let trade_shield_code_id = app.store_code(Box::new(trade_shield_code));
+    let trade_shield_init = InstantiateMockMsg {
+        account_history_address: None,
+        spot_orders: vec![],
+        perpetual_orders: vec![],
+    };
+
+    let addr = app
+        .instantiate_contract(
+            trade_shield_code_id,
+            Addr::unchecked("admin"),
+            &trade_shield_init,
+            &[],
+            "contract",
+            None,
+        )
+        .unwrap();
+
+    let invalid_message = ExecuteMsg::LeveragelpOpen {
+        amm_pool_id: 1,
+        collateral_asset: "uusdc".to_string(),
+        collateral_amount: Int128::new(1000000),
+        leverage: SignedDecimal::one(),
+        stop_loss_price: SignedDecimal::zero(),
+    };
+
+    let valid_message = ExecuteMsg::LeveragelpOpen {
+        amm_pool_id: 1,
+        collateral_asset: "uusdc".to_string(),
+        collateral_amount: Int128::new(1000000),
+        leverage: SignedDecimal::from_str("2.0").unwrap(),
+        stop_loss_price: SignedDecimal::zero(),
+    };
+
+    let error = app
+        .execute_contract(Addr::unchecked("user"), addr.clone(), &invalid_message, &[])
+        .unwrap_err();
+
+    assert_eq!(
+        ContractError::StdError(StdError::generic_err("leverage must be greater than 1")),
+        error.downcast().unwrap()
+    );
+
+    app.execute_contract(Addr::unchecked("user"), addr, &valid_message, &[])
+        .unwrap();
+}

--- a/contracts/trade-shield-contract/src/tests/mod.rs
+++ b/contracts/trade-shield-contract/src/tests/mod.rs
@@ -120,6 +120,12 @@ mod claim_rewards_request {
     mod claim_rewards_request;
 }
 
+mod leveragelp_open {
+    use super::*;
+    mod invalid_collateral;
+    mod invalid_leverage;
+}
+
 pub use mock::instantiate::*;
 mod mock {
     pub mod instantiate;

--- a/scripts/messages.sh
+++ b/scripts/messages.sh
@@ -349,7 +349,7 @@ function leveragelp_open() {
             "leveragelp_open": {
                 "amm_pool_id": 2,
                 "collateral_asset": "'"$usdc_denom"'",
-                "collateral_amount": "0",
+                "collateral_amount": "10000000",
                 "leverage": "1.10",
                 "stop_loss_price": "0.0"
             }

--- a/scripts/messages.sh
+++ b/scripts/messages.sh
@@ -349,8 +349,8 @@ function leveragelp_open() {
             "leveragelp_open": {
                 "amm_pool_id": 2,
                 "collateral_asset": "'"$usdc_denom"'",
-                "collateral_amount": "10000000",
-                "leverage": "5.0",
+                "collateral_amount": "0",
+                "leverage": "1.10",
                 "stop_loss_price": "0.0"
             }
         }' \


### PR DESCRIPTION
## Invalid Leverage
```sh
elysd tx wasm exec --from "validator" --keyring-backend test --node "tcp://localhost:26657" --chain-id elystestnet-1 --gas auto --gas-adjustment=1.3 --fees 100000uelys -b sync -y "elys1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqau4f4q" '{
            "leveragelp_open": {
                "amm_pool_id": 2,
                "collateral_asset": "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65",
                "collateral_amount": "10000000",
                "leverage": "1.0",
                "stop_loss_price": "0.0"
            }
        }'
Error: rpc error: code = Unknown desc = rpc error: code = Unknown desc = failed to execute message; message index: 0: Generic error: leverage must be greater than 1: execute wasm contract failed [!cosm!wasm/wasmd@v0.41.0/x/wasm/keeper/keeper.go:389] With gas wanted: '60000000' and gas used: '114604' : unknown request
```
## Invalid collateral
```sh
elysd tx wasm exec --from "validator" --keyring-backend test --node "tcp://localhost:26657" --chain-id elystestnet-1 --gas auto --gas-adjustment=1.3 --fees 100000uelys -b sync -y "elys1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqau4f4q" '{
            "leveragelp_open": {
                "amm_pool_id": 2,
                "collateral_asset": "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65",
                "collateral_amount": "0",
                "leverage": "1.10",
                "stop_loss_price": "0.0"
            }
        }'
Error: rpc error: code = Unknown desc = rpc error: code = Unknown desc = failed to execute message; message index: 0: Generic error: collateral amount must be greater than 0: execute wasm contract failed [!cosm!wasm/wasmd@v0.41.0/x/wasm/keeper/keeper.go:389] With gas wanted: '60000000' and gas used: '114553' : unknown request
```