### PR TITLE
fix: remove default from reward vec

### DIFF
--- a/bindings/src/query_resp.rs
+++ b/bindings/src/query_resp.rs
@@ -1068,7 +1068,7 @@ impl GetLeverageLpRewardsResp {
         &self,
         querier: &ElysQuerier<'_>,
     ) -> StdResult<Vec<RewardInfoMappedToCoinValue>> {
-        let mut reward_info = vec![RewardInfoMappedToCoinValue::default()];
+        let mut reward_info: Vec<RewardInfoMappedToCoinValue> = vec![];
 
         for reward in &self.rewards {
             let mut coin_values = vec![];


### PR DESCRIPTION
before the fix
```
elysd q --output json --node "tcp://localhost:26657" wasm contract-state smart "elys1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqau4f4q" '{
        "leveragelp_query_positions_for_address": {
           "address" : "elys1u8c28343vvhwgwhf29w6hlcz73hvq7lwxmrl46"
        }
    }' | jq
{
  "data": {
    "positions": {
      "positions": [
        {
          "address": "elys1u8c28343vvhwgwhf29w6hlcz73hvq7lwxmrl46",
          "collateral": {
            "denom": "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65",
            "amount": "345000000"
          },
          "liabilities": "1250500000",
          "interest_paid": "0",
          "leverage": "5",
          "leveraged_lp_amount": "1546934602637489097841",
          "position_health": "0",
          "id": 2,
          "amm_pool_id": 2,
          "stop_loss_price": "0"
        }
      ],
      "rewards": {
        "rewards": [
          **{
            "position_id": 0,
            "reward": []
          },**
          {
            "position_id": 2,
            "reward": []
          }
        ],
        "total_rewards": []
      }
    },
    "pagination": {
      "next_key": null,
      "total": null
    }
  }
}
```

After
```
elysd q --output json --node "tcp://localhost:26657" wasm contract-state smart "elys1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqau4f4q" '{
        "leveragelp_query_positions_for_address": {
           "address" : "elys1u8c28343vvhwgwhf29w6hlcz73hvq7lwxmrl46"
        }
    }' | jq
{
  "data": {
    "positions": {
      "positions": [
        {
          "address": "elys1u8c28343vvhwgwhf29w6hlcz73hvq7lwxmrl46",
          "collateral": {
            "denom": "ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65",
            "amount": "345000000"
          },
          "liabilities": "1250500000",
          "interest_paid": "0",
          "leverage": "5",
          "leveraged_lp_amount": "1546934602637489097841",
          "position_health": "0",
          "id": 2,
          "amm_pool_id": 2,
          "stop_loss_price": "0"
        }
      ],
      "rewards": {
        "rewards": [
          {
            "position_id": 2,
            "reward": []
          }
        ],
        "total_rewards": []
      }
    },
    "pagination": {
      "next_key": null,
      "total": null
    }
  }
}
```
refer this thread:
https://elystalk.slack.com/archives/C06TDTYBFL1/p1718797062809599?thread_ts=1718369245.919219&cid=C06TDTYBFL1
