### PR TITLE
refactor: best practices

### DIFF
--- a/contracts/trade-shield-contract/src/entry_point/instantiate.rs
+++ b/contracts/trade-shield-contract/src/entry_point/instantiate.rs
@@ -12,7 +12,7 @@ pub fn instantiate(
     deps: DepsMut<ElysQuery>,
     _env: Env,
     _info: MessageInfo,
-    msg: InstantiateMsg,
+    _msg: InstantiateMsg,
 ) -> StdResult<Response<ElysMsg>> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     MAX_REPLY_ID.save(deps.storage, &0)?;

--- a/contracts/trade-shield-contract/src/entry_point/migrate.rs
+++ b/contracts/trade-shield-contract/src/entry_point/migrate.rs
@@ -16,7 +16,7 @@ use semver::Version;
 pub fn migrate(
     deps: DepsMut<ElysQuery>,
     _env: Env,
-    msg: MigrateMsg,
+    _msg: MigrateMsg,
 ) -> StdResult<Response<ElysMsg>> {
     let admin = "elys16xffmfa6k45j340cx5zyp66lqvuw62a0neaa7w".to_string();
     PARAMS_ADMIN.save(deps.storage, &admin)?;

--- a/contracts/trade-shield-contract/src/helper.rs
+++ b/contracts/trade-shield-contract/src/helper.rs
@@ -48,10 +48,7 @@ pub fn get_discount(
     }
 
     let val = Uint128::from_str(&discount_str)?;
-    let discount_str = match Decimal::from_atomics(val, 2) {
-        Ok(resp) => resp,
-        Err(_) => Decimal::zero(),
-    };
+    let discount_str = Decimal::from_atomics(val, 2).unwrap_or_default();
     Ok(discount_str)
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.79.0"  # or "nightly", "beta", or a specific version like "1.56.0"
+components = ["rustfmt", "clippy"]  # optional, specify additional components
+targets = ["wasm32-unknown-unknown"]  # optional, specify additional targets


### PR DESCRIPTION
always prefer using unwrap derivatives before using match to make code easy to understand.


and add a rust-toolchain.toml so that everyone is on same version as far as rustc version is concerned